### PR TITLE
Make mapillary image pre-fetch configurable

### DIFF
--- a/src/org/openstreetmap/josm/plugins/mapillary/MapillaryData.java
+++ b/src/org/openstreetmap/josm/plugins/mapillary/MapillaryData.java
@@ -341,19 +341,9 @@ public class MapillaryData {
       this.multiSelectedImages.add(image);
       if (mv != null && image instanceof MapillaryImage) {
         MapillaryImage mapillaryImage = (MapillaryImage) image;
+
         // Downloading thumbnails of surrounding pictures.
-        if (mapillaryImage.next() != null) {
-          CacheUtils.downloadPicture((MapillaryImage) mapillaryImage.next());
-          if (mapillaryImage.next().next() != null) {
-            CacheUtils.downloadPicture((MapillaryImage) mapillaryImage.next().next());
-          }
-        }
-        if (mapillaryImage.previous() != null) {
-          CacheUtils.downloadPicture((MapillaryImage) mapillaryImage.previous());
-          if (mapillaryImage.previous().previous() != null) {
-            CacheUtils.downloadPicture((MapillaryImage) mapillaryImage.previous().previous());
-          }
-        }
+        downloadSurroundingImages(mapillaryImage);
       }
     }
     if (mv != null && zoom && selectedImage != null) {
@@ -361,6 +351,30 @@ public class MapillaryData {
     }
     fireSelectedImageChanged(oldImage, this.selectedImage);
     MapillaryLayer.invalidateInstance();
+  }
+
+  /**
+   * Downloads surrounding images of this mapillary image.
+   * @param mapillaryImage
+   */
+  private void downloadSurroundingImages (MapillaryImage mapillaryImage) {
+    final int prefetchCount = MapillaryProperties.PRE_FETCH_IMAGE_COUNT.get();
+    MapillaryImage nextImage = mapillaryImage;
+    MapillaryImage prevImage = mapillaryImage;
+
+    for (int i = 0; i < prefetchCount; i++) {
+      if (nextImage != null &&
+            nextImage.next() != null) {
+
+        CacheUtils.downloadPicture((MapillaryImage) nextImage.next());
+        nextImage = (MapillaryImage) nextImage.next();
+      }
+      if (prevImage != null &&
+            prevImage.previous() != null) {
+        CacheUtils.downloadPicture((MapillaryImage) prevImage.previous());
+        prevImage = (MapillaryImage) prevImage.previous();
+      }
+    }
   }
 
   private void fireSelectedImageChanged(MapillaryAbstractImage oldImage, MapillaryAbstractImage newImage) {

--- a/src/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSetting.java
+++ b/src/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSetting.java
@@ -20,11 +20,13 @@ import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JTextField;
+import javax.swing.JSpinner;
 import javax.swing.JScrollPane;
 import javax.swing.SwingUtilities;
+import javax.swing.SpinnerNumberModel;
+import javax.swing.JOptionPane;
 
-
+import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.actions.ExpertToggleAction;
 import org.openstreetmap.josm.gui.preferences.PreferenceTabbedPane;
 import org.openstreetmap.josm.gui.preferences.SubPreferenceSetting;
@@ -68,7 +70,8 @@ public class MapillaryPreferenceSetting implements SubPreferenceSetting, Mapilla
     new JCheckBox(I18n.tr("Cut off sequences at download bounds"), MapillaryProperties.CUT_OFF_SEQUENCES_AT_BOUNDS.get());
   private final JCheckBox developer =
     new JCheckBox(I18n.tr("Enable experimental beta-features (might be unstable)"), MapillaryProperties.DEVELOPER.get());
-  private final JTextField preFetchSize = new JTextField("2", 2);
+  private final JSpinner preFetchSize =
+    new JSpinner(new SpinnerNumberModel(MapillaryProperties.PRE_FETCH_IMAGE_COUNT.get().intValue(), 0, Integer.MAX_VALUE, 1));
   private final JButton loginButton = new MapillaryButton(new LoginAction(this));
   private final JButton logoutButton = new MapillaryButton(new LogoutAction());
   private final JLabel loginLabel = new JLabel();
@@ -179,11 +182,15 @@ public class MapillaryPreferenceSetting implements SubPreferenceSetting, Mapilla
     MapillaryProperties.CUT_OFF_SEQUENCES_AT_BOUNDS.put(cutOffSeq.isSelected());
     MapillaryProperties.DEVELOPER.put(developer.isSelected());
 
-    try {
-      Integer prefetch_count = Integer.parseInt(preFetchSize.getText());
+    if (preFetchSize.getModel() instanceof SpinnerNumberModel) {
+            Integer prefetch_count = ((SpinnerNumberModel) preFetchSize.getModel()).getNumber().intValue();
       MapillaryProperties.PRE_FETCH_IMAGE_COUNT.put(prefetch_count);
-    } catch (NumberFormatException e) {
-      Logging.warn("Prefetch Image count is not a valid number. Resetting to default value.");
+    } else {
+      JOptionPane.showMessageDialog(
+        Main.parent,
+        I18n.tr("The Mapillary image prefetch count is not a valid number"),
+        I18n.tr("Warning"),
+        JOptionPane.INFORMATION_MESSAGE);
     }
 
     //Restart is never required

--- a/src/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSetting.java
+++ b/src/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSetting.java
@@ -20,8 +20,10 @@ import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JTextField;
 import javax.swing.JScrollPane;
 import javax.swing.SwingUtilities;
+
 
 import org.openstreetmap.josm.actions.ExpertToggleAction;
 import org.openstreetmap.josm.gui.preferences.PreferenceTabbedPane;
@@ -66,7 +68,7 @@ public class MapillaryPreferenceSetting implements SubPreferenceSetting, Mapilla
     new JCheckBox(I18n.tr("Cut off sequences at download bounds"), MapillaryProperties.CUT_OFF_SEQUENCES_AT_BOUNDS.get());
   private final JCheckBox developer =
     new JCheckBox(I18n.tr("Enable experimental beta-features (might be unstable)"), MapillaryProperties.DEVELOPER.get());
-
+  private final JTextField preFetchSize = new JTextField("", 3);
   private final JButton loginButton = new MapillaryButton(new LoginAction(this));
   private final JButton logoutButton = new MapillaryButton(new LogoutAction());
   private final JLabel loginLabel = new JLabel();
@@ -119,11 +121,17 @@ public class MapillaryPreferenceSetting implements SubPreferenceSetting, Mapilla
     mainPanel.add(moveTo, GBC.eol());
     mainPanel.add(hoverEnabled, GBC.eol());
     mainPanel.add(cutOffSeq, GBC.eol());
+
+    JPanel preFetchPanel = new JPanel();
+    preFetchPanel.add(new JLabel(I18n.tr("Number of images to be pre-fetched (forwards and backwards)")));
+    preFetchPanel.add(preFetchSize);
+    mainPanel.add(preFetchPanel, GBC.eol());
+
     if (ExpertToggleAction.isExpert() || developer.isSelected()) {
       mainPanel.add(developer, GBC.eol());
     }
     MapillaryColorScheme.styleAsDefaultPanel(
-      mainPanel, downloadModePanel, displayHour, format24, moveTo, hoverEnabled, cutOffSeq, developer
+      mainPanel, downloadModePanel, displayHour, format24, moveTo, hoverEnabled, cutOffSeq, developer, preFetchPanel
     );
     mainPanel.add(Box.createVerticalGlue(), GBC.eol().fill(GridBagConstraints.BOTH));
 
@@ -170,6 +178,13 @@ public class MapillaryPreferenceSetting implements SubPreferenceSetting, Mapilla
     MapillaryProperties.HOVER_ENABLED.put(hoverEnabled.isSelected());
     MapillaryProperties.CUT_OFF_SEQUENCES_AT_BOUNDS.put(cutOffSeq.isSelected());
     MapillaryProperties.DEVELOPER.put(developer.isSelected());
+
+    try {
+      Integer prefetch_count = Integer.parseInt(preFetchSize.getText());
+      MapillaryProperties.PRE_FETCH_IMAGE_COUNT.put(prefetch_count);
+    } catch (NumberFormatException e) {
+      Logging.warn("Prefetch Image count is not a valid number. Resetting to default value.");
+    }
 
     //Restart is never required
     return false;

--- a/src/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSetting.java
+++ b/src/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSetting.java
@@ -68,7 +68,7 @@ public class MapillaryPreferenceSetting implements SubPreferenceSetting, Mapilla
     new JCheckBox(I18n.tr("Cut off sequences at download bounds"), MapillaryProperties.CUT_OFF_SEQUENCES_AT_BOUNDS.get());
   private final JCheckBox developer =
     new JCheckBox(I18n.tr("Enable experimental beta-features (might be unstable)"), MapillaryProperties.DEVELOPER.get());
-  private final JTextField preFetchSize = new JTextField("", 3);
+  private final JTextField preFetchSize = new JTextField("2", 2);
   private final JButton loginButton = new MapillaryButton(new LoginAction(this));
   private final JButton logoutButton = new MapillaryButton(new LogoutAction());
   private final JLabel loginLabel = new JLabel();

--- a/src/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryProperties.java
+++ b/src/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryProperties.java
@@ -60,6 +60,11 @@ public final class MapillaryProperties {
   public static final IntegerProperty IMAGEINFO_HELP_COUNTDOWN =
     new IntegerProperty("mapillary.imageInfo.helpDisplayedCountdown", 4);
 
+  /**
+   * The number of images to be prefetched when a mapillary image is selected
+   */
+  public static final IntegerProperty PRE_FETCH_IMAGE_COUNT = new IntegerProperty("mapillary.prefetch-image-count", 2);
+
   private MapillaryProperties() {
     // Private constructor to avoid instantiation
   }


### PR DESCRIPTION
- Allows user to configure the number of images to be pre-fetched
- Puts the image pre-fetch to background worker threads

Relevant JOSM issue: https://josm.openstreetmap.de/ticket/11816