### PR TITLE
Enhancement: view mode for 360-degree panorama (WIP; technical preview)

### DIFF
--- a/src/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryMainDialog.java
+++ b/src/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryMainDialog.java
@@ -94,7 +94,7 @@ public final class MapillaryMainDialog extends ToggleDialog implements
   /**
    * Object containing the shown image and that handles zoom and drag
    */
-  public final MapillaryImageDisplay mapillaryImageDisplay;
+  public MapillaryImageDisplay mapillaryImageDisplay;
 
   private MapillaryCache imageCache;
   private MapillaryCache thumbnailCache;
@@ -211,7 +211,7 @@ public final class MapillaryMainDialog extends ToggleDialog implements
         return;
       }
       if (this.image == null) {
-        this.mapillaryImageDisplay.setImage(null, null);
+        this.mapillaryImageDisplay.setImage(null, null); // FIXME
         setTitle(tr(BASE_TITLE));
         disableAllButtons();
         return;
@@ -248,7 +248,7 @@ public final class MapillaryMainDialog extends ToggleDialog implements
       if (this.image instanceof MapillaryImage) {
         MapillaryImage mapillaryImage = (MapillaryImage) this.image;
         // Downloads the thumbnail.
-        this.mapillaryImageDisplay.setImage(null, null);
+        this.mapillaryImageDisplay.setImage(null, null); // FIXME
         if (this.thumbnailCache != null)
           this.thumbnailCache.cancelOutstandingTasks();
         this.thumbnailCache = new MapillaryCache(mapillaryImage.getKey(),
@@ -275,7 +275,7 @@ public final class MapillaryMainDialog extends ToggleDialog implements
       } else if (this.image instanceof MapillaryImportedImage) {
         MapillaryImportedImage mapillaryImage = (MapillaryImportedImage) this.image;
         try {
-          this.mapillaryImageDisplay.setImage(mapillaryImage.getImage(), null);
+          this.mapillaryImageDisplay.setImage(mapillaryImage.getImage(), null); // FIXME
         } catch (IOException e) {
           Logging.error(e);
         }
@@ -542,9 +542,9 @@ public final class MapillaryMainDialog extends ToggleDialog implements
           return;
         }
         if (
-          mapillaryImageDisplay.getImage() == null
-          || img.getHeight() > this.mapillaryImageDisplay.getImage().getHeight()
-        ) {
+            mapillaryImageDisplay.getImage() == null
+              || img.getHeight() > this.mapillaryImageDisplay.getImage().getHeight()
+            ) {
           final MapillaryAbstractImage mai = getImage();
           this.mapillaryImageDisplay.setImage(
             img,

--- a/src/org/openstreetmap/josm/plugins/mapillary/gui/Rotation.java
+++ b/src/org/openstreetmap/josm/plugins/mapillary/gui/Rotation.java
@@ -1,0 +1,45 @@
+// License: GPL. For details, see LICENSE file.
+package org.openstreetmap.josm.plugins.mapillary.gui;
+
+class Rotation {
+    private double theta;
+    private double sinTheta;
+    private double cosTheta;
+    private double phi;
+    private double sinPhi;
+    private double cosPhi;
+
+    Rotation(double theta, double phi) {
+        setTheta(theta);
+        setPhi(phi);
+    }
+
+    double getTheta() {
+        return theta;
+    }
+
+    void setTheta(double theta) {
+        this.theta = theta;
+        this.sinTheta = Math.sin(theta);
+        this.cosTheta = Math.cos(theta);
+    }
+
+    double getPhi() {
+        return phi;
+    }
+
+    void setPhi(double phi) {
+        this.phi = phi;
+        this.sinPhi = Math.sin(phi);
+        this.cosPhi = Math.cos(phi);
+    }
+
+    Vector3D rotate(Vector3D vec) {
+        double vecX, vecY, vecZ;
+        vecZ = vec.getZ() * cosPhi - vec.getY() * sinPhi;
+        vecY = vec.getZ() * sinPhi + vec.getY() * cosPhi;
+        vecX = vecZ * sinTheta + vec.getX() * cosTheta;
+        vecZ = vecZ * cosTheta - vec.getX() * sinTheta;
+        return new Vector3D(vecX, vecY, vecZ);
+    }
+}

--- a/src/org/openstreetmap/josm/plugins/mapillary/gui/Vector3D.java
+++ b/src/org/openstreetmap/josm/plugins/mapillary/gui/Vector3D.java
@@ -1,0 +1,26 @@
+// License: GPL. For details, see LICENSE file.
+package org.openstreetmap.josm.plugins.mapillary.gui;
+
+public class Vector3D {
+
+    private double x;
+    private double y;
+    private double z;
+
+    public Vector3D(double x, double y, double z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+
+    }
+
+    public double getX() {
+        return x;
+    }
+    public double getY() {
+        return y;
+    }
+    public double getZ() {
+        return z;
+    }
+}

--- a/src/org/openstreetmap/josm/plugins/mapillary/gui/VectorUtil.java
+++ b/src/org/openstreetmap/josm/plugins/mapillary/gui/VectorUtil.java
@@ -1,0 +1,58 @@
+// License: GPL. For details, see LICENSE file.
+package org.openstreetmap.josm.plugins.mapillary.gui;
+
+import java.awt.Point;
+import java.util.stream.IntStream;
+
+class VectorUtil {
+    private Vector3D[][] vectors;
+    private Rotation rotation;
+
+    VectorUtil() {
+        rotation = new Rotation(0, 0);
+    }
+
+    void setCameraScreen(int width, int height, double d) {
+        vectors = new Vector3D[width][height];
+        IntStream.range(0, height).forEach(y -> {
+            IntStream.range(0, width).forEach(x -> {
+                double vecX = x - width / 2;
+                double vecY = y - height / 2;
+                double vecZ = d;
+                double invVecLength = 1 / Math.sqrt(vecX * vecX + vecY * vecY + vecZ * vecZ);
+                vectors[x][y] = new Vector3D(vecX * invVecLength, vecY * invVecLength, vecZ * invVecLength);
+            });
+        });
+    }
+
+    Vector3D getVector3D(int x, int y) {
+        Vector3D res;
+        try {
+            res = rotation.rotate(vectors[x][y]);
+        } catch (Exception e) {
+            res =  new Vector3D(0,0,1);
+        }
+        return res;
+    }
+
+    void setRotation(Vector3D vec) {
+        double theta, phi;
+        try {
+            theta = Math.atan2(vec.getX(), vec.getZ());
+            phi = Math.atan2(vec.getY(), Math.sqrt(vec.getX()*vec.getX() + vec.getZ()*vec.getZ()));
+        } catch (Exception e) {
+            theta = 0; phi = 0;
+        }
+        rotation.setTheta(theta);
+        rotation.setPhi(phi);
+    }
+
+    Point mapping(Vector3D vec, int width, int height) {
+        // https://en.wikipedia.org/wiki/UV_mapping
+        double u = 0.5 + (Math.atan2(vec.getX(), vec.getZ()) / (2 * Math.PI));
+        double v = 0.5 + (Math.asin(vec.getY()) / Math.PI);
+        int tx = (int) ((width - 1) * u);
+        int ty = (int) ((height - 1) * v);
+        return new Point(tx, ty);
+    }
+}


### PR DESCRIPTION
Here is an early stage preview for enhancement. 
Please give me a feedback, and welcome a contribution for  further progress.

- Implement 360 degree panorama photo viewer mode
- Shows a photo image as following data flow;
  `image` -(projection mapping)-> `offscreenImage` buffer -> screen
  instead of normal mode;
  `image` -> screen
- Closes issue #56
- Limitations
  - Disables a zoom feature
  - Use `if(is360)` conditionals. It is better to
    separate two mode as individual classes in future.
  - Fixes `visibleRect`, which control zoom,as same as `offscreenImage` size.
   that is also keep as same as screen size.
  - Disables a drag feature
  - No indication the view direction on the edit pain.
  - No OpenGL accelaration, it may be very slow or consume many CPU
    cycles.
- Recognize as 360 degree photo which thum image is same or larger than 2048px
  width and 2:1 ratio.
  - It do not see EXIF/MXP property because thums don't have it.
  - There are no button to toggle 360 degree photo mode and a normal mode.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>