### PR TITLE
Update JOSM version. Restore image detection & objects features by updating API calls

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ plugin.main.version=14149
 # Version of JOSM against which the plugin is compiled
 # Please check, if the specified version is available for download from https://josm.openstreetmap.de/download/ .
 # If not, choose the next higher number that is available, or the gradle build will break.
-plugin.compile.version=14289
+plugin.compile.version=14620
 plugin.requires=apache-commons;apache-http
 
 # Character encoding of Gradle files

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/model/MapObject.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/model/MapObject.java
@@ -19,26 +19,24 @@ public class MapObject extends KeyIndexedObject {
   private static final Function<String, URL> iconUrlGen = MainWebsite::mapObjectIcon;
 
   private final LatLon coordinate;
-  private final String objPackage;
+  private final String layer;
   private final String value;
   private final long firstSeenTime;
   private final long lastSeenTime;
-  private final long updatedTime;
 
   public MapObject(
-    final LatLon coordinate, final String key, final String objPackage, final String value,
-    long firstSeenTime, long lastSeenTime, long updatedTime
+    final LatLon coordinate, final String key, final String layer, final String value,
+    long firstSeenTime, long lastSeenTime
   ) {
     super(key);
-    if (objPackage == null || value == null || coordinate == null) {
+    if (layer == null || value == null || coordinate == null) {
       throw new IllegalArgumentException("The fields of a MapObject must not be null!");
     }
     this.coordinate = coordinate;
-    this.objPackage = objPackage;
+    this.layer = layer;
     this.value = value;
     this.firstSeenTime = firstSeenTime;
     this.lastSeenTime = lastSeenTime;
-    this.updatedTime = updatedTime;
   }
 
   public LatLon getCoordinate() {
@@ -67,8 +65,8 @@ public class MapObject extends KeyIndexedObject {
     return cachedIcon;
   }
 
-  public String getPackage() {
-    return objPackage;
+  public String getLayer() {
+    return layer;
   }
 
   public long getFirstSeenTime() {
@@ -77,10 +75,6 @@ public class MapObject extends KeyIndexedObject {
 
   public long getLastSeenTime() {
     return lastSeenTime;
-  }
-
-  public long getUpdatedTime() {
-    return updatedTime;
   }
 
   public String getValue() {

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryURL.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryURL.java
@@ -17,6 +17,8 @@ public final class MapillaryURL {
   /** Base URL of the Mapillary API. */
   private static final String BASE_API_V2_URL = "https://a.mapillary.com/v2/";
   private static final String CLIENT_ID = "T1Fzd20xZjdtR0s1VDk5OFNIOXpYdzoxNDYyOGRkYzUyYTFiMzgz";
+  private static final String TRAFFIC_SIGN_LAYER = "trafficsigns";
+
 
   public static final class APIv3 {
     static String baseUrl = "https://a.mapillary.com/v3/";
@@ -37,7 +39,7 @@ public final class MapillaryURL {
     }
 
     public static URL searchDetections(Bounds bounds) {
-      return string2URL(baseUrl, "detections", queryString(bounds));
+      return string2URL(baseUrl, "image_detections", queryString(bounds, TRAFFIC_SIGN_LAYER));
     }
 
     public static URL searchImages(Bounds bounds) {
@@ -45,7 +47,7 @@ public final class MapillaryURL {
     }
 
     public static URL searchMapObjects(final Bounds bounds) {
-      return string2URL(baseUrl, "objects", queryString(bounds));
+      return string2URL(baseUrl, "map_features", queryString(bounds, TRAFFIC_SIGN_LAYER));
     }
 
     public static URL searchSequences(final Bounds bounds) {
@@ -93,6 +95,19 @@ public final class MapillaryURL {
         return MapillaryURL.queryString(parts);
       }
       return MapillaryURL.queryString(null);
+    }
+
+    public static String queryString(final Bounds bounds, final String layer) {
+      if (layer == null) {
+        throw new IllegalArgumentException("layer cannot be null");
+      }
+      final Map<String, String> parts = new HashMap<>();
+      if (bounds != null) {
+        parts.put("bbox", bounds.toBBox().toStringCSV(","));
+      }
+      parts.put("layers", layer);
+      return MapillaryURL.queryString(parts);
+
     }
 
     /**

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonMapObjectDecoder.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonMapObjectDecoder.java
@@ -27,11 +27,11 @@ public final class JsonMapObjectDecoder {
     final JsonValue geometry = json.get("geometry");
     if (properties instanceof JsonObject && geometry instanceof JsonObject) {
       final String key = ((JsonObject) properties).getString("key", null);
-      final String packg = ((JsonObject) properties).getString("package", null);
+      final String layer = ((JsonObject) properties).getString("layer", null);
       final String value = ((JsonObject) properties).getString("value", null);
       final Long firstSeenTime = JsonDecoder.decodeTimestamp(((JsonObject) properties).getString("first_seen_at", null));
       final Long lastSeenTime = JsonDecoder.decodeTimestamp(((JsonObject) properties).getString("last_seen_at", null));
-      final Long updatedTime = JsonDecoder.decodeTimestamp(((JsonObject) properties).getString("updated_at", null));
+      final Long updatedTime = JsonDecoder.decodeTimestamp(((JsonObject) properties).getString("last_seen_at", null));
 
       final JsonValue coordVal = "Point".equals(((JsonObject) geometry).getString("type", null))
         ? ((JsonObject) geometry).get("coordinates")
@@ -40,19 +40,18 @@ public final class JsonMapObjectDecoder {
 
       if (
         key != null &&
-        packg != null &&
+        layer != null &&
         value != null &&
         firstSeenTime != null &&
         lastSeenTime != null &&
-        updatedTime != null &&
         coordinate != null
       ) {
         return new MapObject(
           coordinate,
           key,
-          packg,
+          layer,
           value,
-          firstSeenTime, lastSeenTime, updatedTime
+          firstSeenTime, lastSeenTime
         );
       }
     }

--- a/test/data/api/v3/responses/mapObject.json
+++ b/test/data/api/v3/responses/mapObject.json
@@ -6,8 +6,7 @@
     "first_seen_at": "2016-07-01T12:49:08.553Z",
     "key": "9f3tl0z2xanom2inyyks65negx",
     "last_seen_at": "2016-07-01T12:49:08.553Z",
-    "package": "trafficsign",
-    "updated_at": "2017-02-08T15:02:03.778Z",
+    "layer": "trafficsign",
     "value": "regulatory--no-entry--g1",
     "detections": []
   },

--- a/test/data/api/v3/responses/searchMapObjects.json
+++ b/test/data/api/v3/responses/searchMapObjects.json
@@ -9,8 +9,7 @@
         "first_seen_at": "2016-10-16T09:42:56.060Z",
         "key": "qpku21qv8rjn7fll1v671732th",
         "last_seen_at": "2016-10-16T09:42:56.060Z",
-        "package": "trafficsign",
-        "updated_at": "2016-11-29T12:21:22.275Z",
+        "layer": "trafficsign",
         "value": "regulatory--no-parking--g1",
         "detections": [
           {

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/gui/layer/MapObjectLayerTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/gui/layer/MapObjectLayerTest.java
@@ -62,7 +62,7 @@ public class MapObjectLayerTest {
   @Test
   public void testScheduleDownload() throws InterruptedException, URISyntaxException, IOException {
     stubFor(
-      get(urlMatching("/objects\\?.+"))
+      get(urlMatching("/map_features\\?.+"))
         .withQueryParam("client_id", new EqualToPattern("T1Fzd20xZjdtR0s1VDk5OFNIOXpYdzoxNDYyOGRkYzUyYTFiMzgz"))
         .withQueryParam("bbox", new EqualToPattern("1.0,1.0,1.0,1.0"))
         .willReturn(

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/model/MapObjectTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/model/MapObjectTest.java
@@ -43,9 +43,9 @@ public class MapObjectTest {
   private Object iconUnknownType;
 
   private static void initMapObjects() {
-    mo1 = new MapObject(new LatLon(0, 0), "key1", "", "", 0, 0, 0);
-    mo2 = new MapObject(new LatLon(0, 0), "key2", "", "", 0, 0, 0);
-    mo3 = new MapObject(new LatLon(0, 0), "key1", "", "", 0, 0, 0);
+    mo1 = new MapObject(new LatLon(0, 0), "key1", "", "", 0, 0);
+    mo2 = new MapObject(new LatLon(0, 0), "key2", "", "", 0, 0);
+    mo3 = new MapObject(new LatLon(0, 0), "key1", "", "", 0, 0);
   }
 
   @Before
@@ -66,25 +66,25 @@ public class MapObjectTest {
   @SuppressWarnings({ "unused", "PMD.AvoidDuplicateLiterals" })
   @Test(expected = IllegalArgumentException.class)
   public void testIllArgEx1() {
-    new MapObject(new LatLon(0, 0), null, "", "", 0, 0, 0);
+    new MapObject(new LatLon(0, 0), null, "", "", 0, 0);
   }
 
   @SuppressWarnings("unused")
   @Test(expected = IllegalArgumentException.class)
   public void testIllArgEx2() {
-    new MapObject(new LatLon(0, 0), "", null, "", 0, 0, 0);
+    new MapObject(new LatLon(0, 0), "", null, "", 0, 0);
   }
 
   @SuppressWarnings("unused")
   @Test(expected = IllegalArgumentException.class)
   public void testIllArgEx3() {
-    new MapObject(new LatLon(0, 0), "", "", null, 0, 0, 0);
+    new MapObject(new LatLon(0, 0), "", "", null, 0, 0);
   }
 
   @SuppressWarnings("unused")
   @Test(expected = IllegalArgumentException.class)
   public void testIllArgEx4() {
-    new MapObject(null, "", "", "", 0, 0, 0);
+    new MapObject(null, "", "", "", 0, 0);
   }
 
   @Test

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryURLTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryURLTest.java
@@ -25,7 +25,8 @@ public class MapillaryURLTest {
 
     @Test
     public void testSearchDetections() {
-      assertUrlEquals(MapillaryURL.APIv3.searchDetections(null), "https://a.mapillary.com/v3/detections", CLIENT_ID_QUERY_PART);
+      final String expectedLayerParameter = "layers=trafficsigns";
+      assertUrlEquals(MapillaryURL.APIv3.searchDetections(null), "https://a.mapillary.com/v3/image_detections", CLIENT_ID_QUERY_PART, expectedLayerParameter);
     }
 
     @Test
@@ -47,14 +48,17 @@ public class MapillaryURLTest {
 
     @Test
     public void testSearchMapObjects() throws UnsupportedEncodingException {
+      final String expectedBaseUrl = "https://a.mapillary.com/v3/map_features";
+      final String expectedLayerParameter = "layers=trafficsigns";
       assertUrlEquals(
         MapillaryURL.APIv3.searchMapObjects(new Bounds(new LatLon(1, 2), new LatLon(3, 4), true)),
-        "https://a.mapillary.com/v3/objects",
+        expectedBaseUrl,
         CLIENT_ID_QUERY_PART,
+        expectedLayerParameter,
         "bbox=" + URLEncoder.encode("2.0,1.0,4.0,3.0", StandardCharsets.UTF_8.name())
       );
 
-      assertUrlEquals(MapillaryURL.APIv3.searchMapObjects(null), "https://a.mapillary.com/v3/objects", CLIENT_ID_QUERY_PART);
+      assertUrlEquals(MapillaryURL.APIv3.searchMapObjects(null), expectedBaseUrl, CLIENT_ID_QUERY_PART, expectedLayerParameter);
     }
 
     @Test

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonMapObjectDecoderTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonMapObjectDecoderTest.java
@@ -37,8 +37,7 @@ public class JsonMapObjectDecoderTest {
 
     assertEquals(1_476_610_976_060L, exampleMapObject.getFirstSeenTime()); // 2016-10-16T09:42:56.060 UTC
     assertEquals(1_476_610_976_060L, exampleMapObject.getLastSeenTime()); // 2016-10-16T09:42:56.060 UTC
-    assertEquals(1_480_422_082_275L, exampleMapObject.getUpdatedTime()); // 2016-11-29T12:21:22.275 UTC
-    assertEquals("trafficsign", exampleMapObject.getPackage());
+    assertEquals("trafficsign", exampleMapObject.getLayer());
     assertEquals("regulatory--no-parking--g1", exampleMapObject.getValue());
     assertEquals("qpku21qv8rjn7fll1v671732th", exampleMapObject.getKey());
     assertEquals(new LatLon(55.608367919921875, 13.005650520324707), exampleMapObject.getCoordinate());
@@ -51,11 +50,10 @@ public class JsonMapObjectDecoderTest {
     );
     assertNotNull(exampleMapObject);
     assertEquals("9f3tl0z2xanom2inyyks65negx", exampleMapObject.getKey());
-    assertEquals("trafficsign", exampleMapObject.getPackage());
+    assertEquals("trafficsign", exampleMapObject.getLayer());
     assertEquals("regulatory--no-entry--g1", exampleMapObject.getValue());
     assertEquals(1_467_377_348_553L, exampleMapObject.getLastSeenTime()); // 2016-07-01T12:49:08.553 UTC
     assertEquals(1_467_377_348_553L, exampleMapObject.getFirstSeenTime()); // 2016-07-01T12:49:08.553 UTC
-    assertEquals(1_486_566_123_778L, exampleMapObject.getUpdatedTime()); // 2017-02-08T15:02:03.778 UTC
   }
 
   @Test


### PR DESCRIPTION
- Updated JOSM version.
- Image features: updated API obsolete call:
  - URL: renamed `/detections` to `/image_detections`
  - added parameter: `layers=trafficsigns`.
- Object features: updated API obsolete call:
  - URL: renamed `/objects` to `/map_features`
  - added parameter: `layers=trafficsigns`
  - JSON payload: 
    - removed `updated_at` obsolete attribute
    - renamed `package` to `layer`.
