### PR TITLE
Feature/image panel: black background

### DIFF
--- a/mapillary_structure.json
+++ b/mapillary_structure.json
@@ -1,0 +1,38 @@
+{
+  "description": "Mapillary JSOM plugin",
+  "frameworks": [
+    "swing"
+  ],
+  "language": "java",
+  "maintainers": [
+    "jpietri"
+  ],
+  "providers": [
+    {
+      "dependencies": [
+        {
+          "name": "api_v2"
+        },
+        {
+          "name": "api_v3"
+        }
+      ],
+      "extDependencies": [
+        {
+          "documentation": "https://josm.openstreetmap.de/",
+          "name": "JOSM"
+        }
+      ],
+      "description": "Mapillary JSOM plugin",
+      "name": "josm_mapillary_plugin_provider",
+      "services": [
+        {
+          "description": "Mapillary JSOM plugin",
+          "name": "josm_mapillary_plugin"
+        }
+      ],
+      "type": "app_desktop"
+    }
+  ],
+  "repo": "josm-mapillary-plugin"
+}

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryImageDisplay.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryImageDisplay.java
@@ -402,7 +402,7 @@ public class MapillaryImageDisplay extends JComponent {
     ImgDisplayMouseListener mouseListener = new ImgDisplayMouseListener();
     addMouseListener(mouseListener);
     setOpaque(true);
-    setBackground(Color.BLACK);
+    setBackground(MapillaryProperties.BLACK_BACKGROUND.get() ? Color.BLACK : Color.WHITE);
     addMouseWheelListener(mouseListener);
     addMouseMotionListener(mouseListener);
     addComponentListener(new ComponentSizeListener());

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSetting.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSetting.java
@@ -68,9 +68,9 @@ public class MapillaryPreferenceSetting implements SubPreferenceSetting, Mapilla
   private final JCheckBox hoverEnabled =
     // i18n: Checkbox label in JOSM settings
     new JCheckBox(I18n.tr("Preview images when hovering its icon"), MapillaryProperties.HOVER_ENABLED.get());
-  private final JCheckBox blackBackground =
+  private final JCheckBox darkMode =
     // i18n: Checkbox label in JOSM settings
-    new JCheckBox(I18n.tr("Image panel black background"), MapillaryProperties.BLACK_BACKGROUND.get());
+    new JCheckBox(I18n.tr("Dark mode for image display"), MapillaryProperties.DARK_MODE.get());
   private final JCheckBox cutOffSeq =
     // i18n: Checkbox label in JOSM settings
     new JCheckBox(I18n.tr("Cut off sequences at download bounds"), MapillaryProperties.CUT_OFF_SEQUENCES_AT_BOUNDS.get());
@@ -140,7 +140,7 @@ public class MapillaryPreferenceSetting implements SubPreferenceSetting, Mapilla
     mainPanel.add(format24, GBC.eol());
     mainPanel.add(moveTo, GBC.eol());
     mainPanel.add(hoverEnabled, GBC.eol());
-    mainPanel.add(blackBackground, GBC.eol());
+    mainPanel.add(darkMode, GBC.eol());
     mainPanel.add(cutOffSeq, GBC.eol());
     mainPanel.add(imageLinkToBlurEditor, GBC.eol());
 
@@ -158,7 +158,7 @@ public class MapillaryPreferenceSetting implements SubPreferenceSetting, Mapilla
       mainPanel.add(developer, GBC.eol());
     }
     MapillaryColorScheme.styleAsDefaultPanel(
-      mainPanel, downloadModePanel, displayHour, format24, moveTo, hoverEnabled, blackBackground, cutOffSeq, imageLinkToBlurEditor, developer, preFetchPanel
+      mainPanel, downloadModePanel, displayHour, format24, moveTo, hoverEnabled, darkMode, cutOffSeq, imageLinkToBlurEditor, developer, preFetchPanel
     );
     mainPanel.add(Box.createVerticalGlue(), GBC.eol().fill(GridBagConstraints.BOTH));
 
@@ -203,7 +203,7 @@ public class MapillaryPreferenceSetting implements SubPreferenceSetting, Mapilla
     MapillaryProperties.TIME_FORMAT_24.put(format24.isSelected());
     MapillaryProperties.MOVE_TO_IMG.put(moveTo.isSelected());
     MapillaryProperties.HOVER_ENABLED.put(hoverEnabled.isSelected());
-    MapillaryProperties.BLACK_BACKGROUND.put(blackBackground.isSelected());
+    MapillaryProperties.DARK_MODE.put(darkMode.isSelected());
     MapillaryProperties.CUT_OFF_SEQUENCES_AT_BOUNDS.put(cutOffSeq.isSelected());
     MapillaryProperties.IMAGE_LINK_TO_BLUR_EDITOR.put(imageLinkToBlurEditor.isSelected());
     MapillaryProperties.DEVELOPER.put(developer.isSelected());

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSetting.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSetting.java
@@ -68,6 +68,9 @@ public class MapillaryPreferenceSetting implements SubPreferenceSetting, Mapilla
   private final JCheckBox hoverEnabled =
     // i18n: Checkbox label in JOSM settings
     new JCheckBox(I18n.tr("Preview images when hovering its icon"), MapillaryProperties.HOVER_ENABLED.get());
+  private final JCheckBox blackBackground =
+    // i18n: Checkbox label in JOSM settings
+    new JCheckBox(I18n.tr("Image panel black background"), MapillaryProperties.BLACK_BACKGROUND.get());
   private final JCheckBox cutOffSeq =
     // i18n: Checkbox label in JOSM settings
     new JCheckBox(I18n.tr("Cut off sequences at download bounds"), MapillaryProperties.CUT_OFF_SEQUENCES_AT_BOUNDS.get());
@@ -137,6 +140,7 @@ public class MapillaryPreferenceSetting implements SubPreferenceSetting, Mapilla
     mainPanel.add(format24, GBC.eol());
     mainPanel.add(moveTo, GBC.eol());
     mainPanel.add(hoverEnabled, GBC.eol());
+    mainPanel.add(blackBackground, GBC.eol());
     mainPanel.add(cutOffSeq, GBC.eol());
     mainPanel.add(imageLinkToBlurEditor, GBC.eol());
 
@@ -154,7 +158,7 @@ public class MapillaryPreferenceSetting implements SubPreferenceSetting, Mapilla
       mainPanel.add(developer, GBC.eol());
     }
     MapillaryColorScheme.styleAsDefaultPanel(
-      mainPanel, downloadModePanel, displayHour, format24, moveTo, hoverEnabled, cutOffSeq, imageLinkToBlurEditor, developer, preFetchPanel
+      mainPanel, downloadModePanel, displayHour, format24, moveTo, hoverEnabled, blackBackground, cutOffSeq, imageLinkToBlurEditor, developer, preFetchPanel
     );
     mainPanel.add(Box.createVerticalGlue(), GBC.eol().fill(GridBagConstraints.BOTH));
 
@@ -199,6 +203,7 @@ public class MapillaryPreferenceSetting implements SubPreferenceSetting, Mapilla
     MapillaryProperties.TIME_FORMAT_24.put(format24.isSelected());
     MapillaryProperties.MOVE_TO_IMG.put(moveTo.isSelected());
     MapillaryProperties.HOVER_ENABLED.put(hoverEnabled.isSelected());
+    MapillaryProperties.BLACK_BACKGROUND.put(blackBackground.isSelected());
     MapillaryProperties.CUT_OFF_SEQUENCES_AT_BOUNDS.put(cutOffSeq.isSelected());
     MapillaryProperties.IMAGE_LINK_TO_BLUR_EDITOR.put(imageLinkToBlurEditor.isSelected());
     MapillaryProperties.DEVELOPER.put(developer.isSelected());

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryProperties.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryProperties.java
@@ -17,7 +17,7 @@ public final class MapillaryProperties {
   public static final BooleanProperty DEVELOPER = new BooleanProperty("mapillary.developer", false);
   public static final BooleanProperty DISPLAY_HOUR = new BooleanProperty("mapillary.display-hour", true);
   public static final BooleanProperty HOVER_ENABLED = new BooleanProperty("mapillary.hover-enabled", true);
-  public static final BooleanProperty BLACK_BACKGROUND = new BooleanProperty("mapillary.black-background", true);
+  public static final BooleanProperty DARK_MODE = new BooleanProperty("mapillary.dark-mode", true);
   public static final BooleanProperty MOVE_TO_IMG = new BooleanProperty("mapillary.move-to-picture", true);
   public static final BooleanProperty TIME_FORMAT_24 = new BooleanProperty("mapillary.format-24", true);
   public static final BooleanProperty IMAGE_LINK_TO_BLUR_EDITOR = new BooleanProperty("mapillary.image-link-to-blur-editor", false);

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryProperties.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryProperties.java
@@ -17,6 +17,7 @@ public final class MapillaryProperties {
   public static final BooleanProperty DEVELOPER = new BooleanProperty("mapillary.developer", false);
   public static final BooleanProperty DISPLAY_HOUR = new BooleanProperty("mapillary.display-hour", true);
   public static final BooleanProperty HOVER_ENABLED = new BooleanProperty("mapillary.hover-enabled", true);
+  public static final BooleanProperty BLACK_BACKGROUND = new BooleanProperty("mapillary.black-background", true);
   public static final BooleanProperty MOVE_TO_IMG = new BooleanProperty("mapillary.move-to-picture", true);
   public static final BooleanProperty TIME_FORMAT_24 = new BooleanProperty("mapillary.format-24", true);
   public static final BooleanProperty IMAGE_LINK_TO_BLUR_EDITOR = new BooleanProperty("mapillary.image-link-to-blur-editor", false);

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSettingTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryPreferenceSettingTest.java
@@ -86,6 +86,7 @@ public class MapillaryPreferenceSettingTest {
     new StringProperty("mapillary.format-24", "default").put("arbitrary");
     new StringProperty("mapillary.move-to-picture", "default").put("arbitrary");
     new StringProperty("mapillary.hover-enabled", "default").put("arbitrary");
+    new StringProperty("mapillary.black-background", "default").put("arbitrary");
     new StringProperty("mapillary.download-mode", "default").put("arbitrary");
     new StringProperty("mapillary.prefetch-image-count", "default").put("arbitrary");
 
@@ -95,6 +96,7 @@ public class MapillaryPreferenceSettingTest {
     assertPropertyMatchesCheckboxSelection((JCheckBox) getPrivateFieldValue(settings, "format24"), "mapillary.format-24");
     assertPropertyMatchesCheckboxSelection((JCheckBox) getPrivateFieldValue(settings, "moveTo"), "mapillary.move-to-picture");
     assertPropertyMatchesCheckboxSelection((JCheckBox) getPrivateFieldValue(settings, "hoverEnabled"), "mapillary.hover-enabled");
+    assertPropertyMatchesCheckboxSelection((JCheckBox) getPrivateFieldValue(settings, "blackBackground"), "mapillary.black-background");
     assertEquals(String.valueOf(((SpinnerNumberModel) getPrivateFieldValue(settings, "preFetchSize")).getNumber().intValue()), new StringProperty("mapillary.prefetch-image-count", "default").get());
 
     // Toggle state of the checkboxes
@@ -102,6 +104,7 @@ public class MapillaryPreferenceSettingTest {
     toggleCheckbox((JCheckBox) getPrivateFieldValue(settings, "format24"));
     toggleCheckbox((JCheckBox) getPrivateFieldValue(settings, "moveTo"));
     toggleCheckbox((JCheckBox) getPrivateFieldValue(settings, "hoverEnabled"));
+    toggleCheckbox((JCheckBox) getPrivateFieldValue(settings, "blackBackground"));
     ((SpinnerNumberModel) getPrivateFieldValue(settings, "preFetchSize")).setValue(73);
 
     // Test the second state of the checkboxes
@@ -110,6 +113,7 @@ public class MapillaryPreferenceSettingTest {
     assertPropertyMatchesCheckboxSelection((JCheckBox) getPrivateFieldValue(settings, "format24"), "mapillary.format-24");
     assertPropertyMatchesCheckboxSelection((JCheckBox) getPrivateFieldValue(settings, "moveTo"), "mapillary.move-to-picture");
     assertPropertyMatchesCheckboxSelection((JCheckBox) getPrivateFieldValue(settings, "hoverEnabled"), "mapillary.hover-enabled");
+    assertPropertyMatchesCheckboxSelection((JCheckBox) getPrivateFieldValue(settings, "blackBackground"), "mapillary.black-background");
     assertEquals(String.valueOf(((SpinnerNumberModel) getPrivateFieldValue(settings, "preFetchSize")).getNumber().intValue()), new StringProperty("mapillary.prefetch-image-count", "default").get());
 
     // Test combobox


### PR DESCRIPTION
- On demand from extensive users: set the image panel background to black, to reduce the flickering effect while navigating through the images (typically with the _Next picture_ button), that causes eye tiredness.
- Added an option to come back to the white background if preferred.
- Extracted two methods from `MapillaryImageDisplay.paintComponent(g)`.