### PR TITLE
Detect panorama from images detail response

### DIFF
--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryAbstractImage.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryAbstractImage.java
@@ -5,6 +5,7 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
+import java.util.Optional;
 
 import org.openstreetmap.josm.data.coor.LatLon;
 import org.openstreetmap.josm.plugins.mapillary.utils.MapillaryProperties;
@@ -34,7 +35,7 @@ public abstract class MapillaryAbstractImage implements Comparable<MapillaryAbst
   /** Temporal position of the picture until it is uploaded. */
   private LatLon tempLatLon;
   /** Picture is panorama/360degree VR photo or not */
-  private boolean pano;
+  private Optional<Boolean> pano;
 
   /**
    * When the object is being dragged in the map, the temporal position is
@@ -57,14 +58,13 @@ public abstract class MapillaryAbstractImage implements Comparable<MapillaryAbst
    * @param latLon  The latitude and longitude where the picture was taken.
    * @param ca  The direction of the picture (0 means north).
    */
-  protected MapillaryAbstractImage(final LatLon latLon, final double ca, final boolean pano) {
+  protected MapillaryAbstractImage(final LatLon latLon, final double ca) {
     this.latLon = latLon;
     this.tempLatLon = this.latLon;
     this.movingLatLon = this.latLon;
     this.ca = ca;
     this.tempCa = ca;
     this.movingCa = ca;
-    this.pano = pano;
     this.visible = true;
   }
 
@@ -87,7 +87,7 @@ public abstract class MapillaryAbstractImage implements Comparable<MapillaryAbst
   }
 
   public boolean isPanorama() {
-    return this.pano;
+    return this.pano.orElse(false);
   }
 
   /**
@@ -262,7 +262,7 @@ public abstract class MapillaryAbstractImage implements Comparable<MapillaryAbst
   }
 
   public void setPanorama(final boolean pano) {
-    this.pano = pano;
+    this.pano = Optional.of(pano);
   }
 
   /**

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryAbstractImage.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryAbstractImage.java
@@ -33,8 +33,8 @@ public abstract class MapillaryAbstractImage implements Comparable<MapillaryAbst
   protected double ca;
   /** Temporal position of the picture until it is uploaded. */
   private LatLon tempLatLon;
-
-  private final boolean pano;
+  /** Picture is panorama/360degree VR photo or not */
+  private boolean pano;
 
   /**
    * When the object is being dragged in the map, the temporal position is
@@ -259,6 +259,10 @@ public abstract class MapillaryAbstractImage implements Comparable<MapillaryAbst
     if (latLon != null) {
       this.latLon = latLon;
     }
+  }
+
+  public void setPanorama(final boolean pano) {
+    this.pano = pano;
   }
 
   /**

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryImage.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryImage.java
@@ -35,8 +35,8 @@ public class MapillaryImage extends MapillaryAbstractImage {
    * @param latLon The latitude and longitude where it is positioned.
    * @param ca     The direction of the images in degrees, meaning 0 north.
    */
-  public MapillaryImage(final String key, final LatLon latLon, final double ca, final boolean pano) {
-    super(latLon, ca, pano);
+  public MapillaryImage(final String key, final LatLon latLon, final double ca) {
+    super(latLon, ca);
     this.key = key;
   }
 

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryImportedImage.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryImportedImage.java
@@ -89,7 +89,7 @@ public class MapillaryImportedImage extends MapillaryAbstractImage {
   }
 
   public MapillaryImportedImage(final LatLon latLon, final double ca, final File file, final long capturedAt) {
-    super(latLon, ca, false);
+    super(latLon, ca);
     this.file = file;
     this.capturedAt = capturedAt;
   }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonImageDetailsDecoder.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonImageDetailsDecoder.java
@@ -31,11 +31,15 @@ public final class JsonImageDetailsDecoder {
       JsonValue properties = json.get("properties");
       if (properties instanceof JsonObject) {
         String key = ((JsonObject) properties).getString("key", null);
-        Long capturedAt = JsonDecoder.decodeTimestamp(((JsonObject)properties).getString("captured_at", null));
+        Long capturedAt = JsonDecoder.decodeTimestamp(((JsonObject) properties).getString("captured_at", null));
+        boolean pano = ((JsonObject) properties).getBoolean("pano", false);
         if (key != null && capturedAt != null) {
           data.getImages().stream().filter(
             img -> img instanceof MapillaryImage && key.equals(((MapillaryImage) img).getKey())
-          ).forEach(img -> img.setCapturedAt(capturedAt));
+          ).forEach(img -> {
+            img.setCapturedAt(capturedAt);
+            img.setPanorama(pano);
+          });
         }
       }
     }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonSequencesDecoder.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonSequencesDecoder.java
@@ -55,10 +55,9 @@ public final class JsonSequencesDecoder {
       );
       final LatLon[] geometry = decodeLatLons(json.getJsonObject("geometry"));
       final int sequenceLength = Math.min(Math.min(cas.length, imageKeys.length), geometry.length);
-      boolean pano = properties.getBoolean("pano", false);
       for (int i = 0; i < sequenceLength; i++) {
         if (cas[i] != null && imageKeys[i] != null && geometry[i] != null) {
-          final MapillaryImage img = new MapillaryImage(imageKeys[i], geometry[i], cas[i], pano);
+          final MapillaryImage img = new MapillaryImage(imageKeys[i], geometry[i], cas[i]);
           result.add(img);
         }
       }

--- a/test/data/api/v3/responses/searchImages.json
+++ b/test/data/api/v3/responses/searchImages.json
@@ -27,7 +27,7 @@
         "camera_make": "Apple",
         "captured_at": "2017-04-10T05:51:26.853Z",
         "key": "nmF-Wq4EvVTgAUmBicSCCg",
-        "pano": false,
+        "pano": true,
         "user_key": "UtczWn8y3afb0GQVW-AiOQ",
         "username": "xtyou"
       },

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/MapillaryAbstractImageTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/MapillaryAbstractImageTest.java
@@ -56,7 +56,7 @@ public class MapillaryAbstractImageTest {
 
   @Test
   public void testIsModified() {
-    MapillaryImage img = new MapillaryImage("key___________________", new LatLon(0, 0), 0, false);
+    MapillaryImage img = new MapillaryImage("key___________________", new LatLon(0, 0), 0);
     assertFalse(img.isModified());
     img.turn(1e-4);
     img.stopMoving();

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/MapillaryDataTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/MapillaryDataTest.java
@@ -38,10 +38,10 @@ public class MapillaryDataTest {
    */
   @Before
   public void setUp() {
-    this.img1 = new MapillaryImage("key1__________________", new LatLon(0.1, 0.1), 90, false);
-    this.img2 = new MapillaryImage("key2__________________", new LatLon(0.2, 0.2), 90, false);
-    this.img3 = new MapillaryImage("key3__________________", new LatLon(0.3, 0.3), 90, false);
-    this.img4 = new MapillaryImage("key4__________________", new LatLon(0.4, 0.4), 90, false);
+    this.img1 = new MapillaryImage("key1__________________", new LatLon(0.1, 0.1), 90);
+    this.img2 = new MapillaryImage("key2__________________", new LatLon(0.2, 0.2), 90);
+    this.img3 = new MapillaryImage("key3__________________", new LatLon(0.3, 0.3), 90);
+    this.img4 = new MapillaryImage("key4__________________", new LatLon(0.4, 0.4), 90);
     final MapillarySequence seq = new MapillarySequence();
 
     seq.add(Arrays.asList(img1, img2, img3, img4));
@@ -74,7 +74,7 @@ public class MapillaryDataTest {
   @Test
   public void sizeTest() {
     assertEquals(4, this.data.getImages().size());
-    this.data.add(new MapillaryImage("key5__________________", new LatLon(0.1, 0.1), 90, false));
+    this.data.add(new MapillaryImage("key5__________________", new LatLon(0.1, 0.1), 90));
     assertEquals(5, this.data.getImages().size());
   }
 

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/MapillarySequenceTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/MapillarySequenceTest.java
@@ -21,11 +21,11 @@ import org.openstreetmap.josm.data.coor.LatLon;
  */
 public class MapillarySequenceTest {
 
-  private final MapillaryImage img1 = new MapillaryImage("key1", new LatLon(0.1, 0.1), 90, false);
-  private final MapillaryImage img2 = new MapillaryImage("key2", new LatLon(0.2, 0.2), 90, false);
-  private final MapillaryImage img3 = new MapillaryImage("key3", new LatLon(0.3, 0.3), 90, false);
-  private final MapillaryImage img4 = new MapillaryImage("key4", new LatLon(0.4, 0.4), 90, false);
-  private final MapillaryImage imgWithoutSeq = new MapillaryImage("key5", new LatLon(0.5, 0.5), 90, false);
+  private final MapillaryImage img1 = new MapillaryImage("key1", new LatLon(0.1, 0.1), 90);
+  private final MapillaryImage img2 = new MapillaryImage("key2", new LatLon(0.2, 0.2), 90);
+  private final MapillaryImage img3 = new MapillaryImage("key3", new LatLon(0.3, 0.3), 90);
+  private final MapillaryImage img4 = new MapillaryImage("key4", new LatLon(0.4, 0.4), 90);
+  private final MapillaryImage imgWithoutSeq = new MapillaryImage("key5", new LatLon(0.5, 0.5), 90);
   private final MapillarySequence seq = new MapillarySequence();
 
   /**

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/history/MapillaryRecordTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/history/MapillaryRecordTest.java
@@ -52,9 +52,9 @@ public class MapillaryRecordTest {
   @Before
   public void setUp() {
     record = new MapillaryRecord();
-    img1 = new MapillaryImage("key1__________________", new LatLon(0.1, 0.1), 0.1, false);
-    img2 = new MapillaryImage("key2__________________", new LatLon(0.2, 0.2), 0.2, false);
-    img3 = new MapillaryImage("key3__________________", new LatLon(0.3, 0.3), 0.3, false);
+    img1 = new MapillaryImage("key1__________________", new LatLon(0.1, 0.1), 0.1);
+    img2 = new MapillaryImage("key2__________________", new LatLon(0.2, 0.2), 0.2);
+    img3 = new MapillaryImage("key3__________________", new LatLon(0.3, 0.3), 0.3);
     if (MapillaryLayer.hasInstance() && MapillaryLayer.getInstance().getData().getImages().size() >= 1) {
       MapillaryLayer.getInstance().getData().getImages().clear();
     }

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonImageDetailsDecoderTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonImageDetailsDecoderTest.java
@@ -53,6 +53,8 @@ public class JsonImageDetailsDecoderTest {
     assertEquals(1_491_803_486_853L, img2.getCapturedAt()); // 2017-04-10T05:51:26.853Z
     assertEquals(0L, img3.getCapturedAt());
     assertEquals(0L, img4.getCapturedAt());
+    assertEquals(false, img1.isPanorama());
+    assertEquals(true, img2.isPanorama());
   }
 
   @Test

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonImageDetailsDecoderTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonImageDetailsDecoderTest.java
@@ -39,9 +39,9 @@ public class JsonImageDetailsDecoderTest {
       JsonImageDetailsDecoderTest.class.getResourceAsStream("/api/v3/responses/searchImages.json")
     ).readObject();
     MapillaryData data = new MapillaryDataMock();
-    MapillaryImage img1 = new MapillaryImage("_yA5uXuSNugmsK5VucU6Bg", new LatLon(0, 0), 0, false);
-    MapillaryImage img2 = new MapillaryImage("nmF-Wq4EvVTgAUmBicSCCg", new LatLon(0, 0), 0, false);
-    MapillaryImage img3 = new MapillaryImage("arbitrary_key", new LatLon(0, 0), 0, false);
+    MapillaryImage img1 = new MapillaryImage("_yA5uXuSNugmsK5VucU6Bg", new LatLon(0, 0), 0);
+    MapillaryImage img2 = new MapillaryImage("nmF-Wq4EvVTgAUmBicSCCg", new LatLon(0, 0), 0);
+    MapillaryImage img3 = new MapillaryImage("arbitrary_key", new LatLon(0, 0), 0);
     MapillaryAbstractImage img4 = new MapillaryImportedImage(new LatLon(0, 0), 0, null);
     img4.setCapturedAt(0);
     data.add(img1);

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonLocationChangesetEncoderTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonLocationChangesetEncoderTest.java
@@ -23,17 +23,17 @@ import org.openstreetmap.josm.plugins.mapillary.utils.TestUtil;
 public class JsonLocationChangesetEncoderTest {
   @Test
   public void test() throws IllegalArgumentException {
-    MapillaryImage img1 = new MapillaryImage("wMAqAFr3xE9072G8Al6WLQ", new LatLon(0, 0), 0, false);
+    MapillaryImage img1 = new MapillaryImage("wMAqAFr3xE9072G8Al6WLQ", new LatLon(0, 0), 0);
     img1.move(13.3323, 50.44612);
     img1.turn(273.3);
     img1.stopMoving();
-    MapillaryImage img2 = new MapillaryImage("7erPn382xDMtmfdh0xtvUw", new LatLon(0, 0), 0, false);
+    MapillaryImage img2 = new MapillaryImage("7erPn382xDMtmfdh0xtvUw", new LatLon(0, 0), 0);
     img2.move(13.3328, 50.44619);
     img2.stopMoving();
-    MapillaryImage img3 = new MapillaryImage("31KDbCOzla0fJBtIeoBr1A", new LatLon(0, 0), 0, false);
+    MapillaryImage img3 = new MapillaryImage("31KDbCOzla0fJBtIeoBr1A", new LatLon(0, 0), 0);
     img3.turn(13.4);
     img3.stopMoving();
-    MapillaryImage img4 = new MapillaryImage("invalid image key will be ignored", new LatLon(0, 0), 0, false);
+    MapillaryImage img4 = new MapillaryImage("invalid image key will be ignored", new LatLon(0, 0), 0);
     img4.turn(13.4);
     img4.stopMoving();
 

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonSequencesDecoderTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonSequencesDecoderTest.java
@@ -55,6 +55,11 @@ public class JsonSequencesDecoderTest {
     assertEquals(new LatLon(7.248372, 16.432971),  seq.getImages().get(2).getLatLon());
     assertEquals(new LatLon(7.249027, 16.432976),  seq.getImages().get(3).getLatLon());
 
+    assertEquals(false, seq.getImages().get(0).isPanorama());
+    assertEquals(false, seq.getImages().get(1).isPanorama());
+    assertEquals(false, seq.getImages().get(2).isPanorama());
+    assertEquals(false, seq.getImages().get(3).isPanorama());
+
     assertEquals(1_457_963_093_860L, seq.getCapturedAt()); // 2016-03-14T13:44:53.860 UTC
   }
 

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonSequencesDecoderTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonSequencesDecoderTest.java
@@ -104,11 +104,11 @@ public class JsonSequencesDecoderTest {
     assertEquals(2, exampleSequence.getImages().size());
 
     assertEquals(
-      new MapillaryImage("76P0YUrlDD_lF6J7Od3yoA", new LatLon(16.43279, 7.246085), 96.71454, false),
+      new MapillaryImage("76P0YUrlDD_lF6J7Od3yoA", new LatLon(16.43279, 7.246085), 96.71454),
       exampleSequence.getImages().get(0)
     );
     assertEquals(
-      new MapillaryImage("Ap_8E0BwoAqqewhJaEbFyQ", new LatLon(16.432799, 7.246082), 96.47705000000002, false),
+      new MapillaryImage("Ap_8E0BwoAqqewhJaEbFyQ", new LatLon(16.432799, 7.246082), 96.47705000000002),
       exampleSequence.getImages().get(1)
     );
   }


### PR DESCRIPTION
Sometimes sequences API response does not include "pano" parameter.(#88)
So it try to detect "pano" property in images API.
https://www.mapillary.com/developer/api-documentation/#the-image

Signed-off-by: Hiroshi Miura <miurahr@linux.com>