### PR TITLE
fix(OSM changeset): add mapillary as source

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,12 +5,12 @@ plugin.description=Allows the user to work with pictures hosted at mapillary.com
 plugin.icon=images/mapillary-logo.svg
 plugin.link=https://wiki.openstreetmap.org/wiki/JOSM/Plugins/Mapillary
 # Minimum required JOSM version to run this plugin, choose the lowest version possible that is compatible.
-# You can check if the plugin compiles against this version by executing `./gradlew minJosmVersionClasses`.
-plugin.main.version=14760
+# You can check if the plugin compiles against this version by executing `./gradlew compileJava_minJosm`.
+plugin.main.version=15371
 # Version of JOSM against which the plugin is compiled
 # Please check, if the specified version is available for download from https://josm.openstreetmap.de/download/ .
 # If not, choose the next higher number that is available, or the gradle build will break.
-plugin.compile.version=15238
+plugin.compile.version=15438
 plugin.requires=apache-commons;apache-http
 
 # Character encoding of Gradle files

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryLayer.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryLayer.java
@@ -413,6 +413,11 @@ public final class MapillaryLayer extends AbstractModifiableLayer implements
   }
 
   @Override
+  public String getChangesetSourceTag() {
+    return "mapillary";
+  }
+
+  @Override
   public boolean isMergable(Layer other) {
     return false;
   }

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/MapillaryLayerTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/MapillaryLayerTest.java
@@ -1,6 +1,7 @@
 // License: GPL. For details, see LICENSE file.
 package org.openstreetmap.josm.plugins.mapillary;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -66,6 +67,12 @@ public class MapillaryLayerTest {
     Object comp = MapillaryLayer.getInstance().getInfoComponent();
     assertTrue(comp instanceof String);
     assertTrue(((String) comp).length() >= 9);
+  }
+
+  @Test
+  public void testGetChangesetSourceTag() {
+    String actualChangesetSourceTag = MapillaryLayer.getInstance().getChangesetSourceTag();
+    assertEquals("OpenStreetmap changeset source for Mapillary layer should be 'mapillary'", "mapillary", actualChangesetSourceTag);
   }
 
   @Test


### PR DESCRIPTION
fix: add mapillary as a source for the OSM changeset, when clicking on _obtain from current layers_