### PR TITLE
Don't redownload images that are already obtained.

### DIFF
--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/cache/CacheUtils.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/cache/CacheUtils.java
@@ -55,21 +55,12 @@ public final class CacheUtils {
    *          both.)
    */
   public static void downloadPicture(MapillaryImage img, PICTURE pic) {
-    switch (pic) {
-      case BOTH:
-        if (new MapillaryCache(img.getKey(), MapillaryCache.Type.THUMBNAIL).get() == null)
-          submit(img.getKey(), MapillaryCache.Type.THUMBNAIL, IGNORE_DOWNLOAD);
-        if (new MapillaryCache(img.getKey(), MapillaryCache.Type.FULL_IMAGE).get() == null)
-          submit(img.getKey(), MapillaryCache.Type.FULL_IMAGE, IGNORE_DOWNLOAD);
-        break;
-      case THUMBNAIL:
-        submit(img.getKey(), MapillaryCache.Type.THUMBNAIL, IGNORE_DOWNLOAD);
-        break;
-      case FULL_IMAGE:
-      default:
-        submit(img.getKey(), MapillaryCache.Type.FULL_IMAGE, IGNORE_DOWNLOAD);
-        break;
-    }
+    boolean thumbnail = new MapillaryCache(img.getKey(), MapillaryCache.Type.THUMBNAIL).get() == null && (PICTURE.BOTH.equals(pic) || PICTURE.THUMBNAIL.equals(pic));
+    boolean fullImage = new MapillaryCache(img.getKey(), MapillaryCache.Type.FULL_IMAGE).get() == null && (PICTURE.BOTH.equals(pic) || PICTURE.FULL_IMAGE.equals(pic));
+    if (thumbnail)
+      submit(img.getKey(), MapillaryCache.Type.THUMBNAIL, IGNORE_DOWNLOAD);
+    if (fullImage)
+      submit(img.getKey(), MapillaryCache.Type.FULL_IMAGE, IGNORE_DOWNLOAD);
   }
 
   /**

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryMainDialog.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryMainDialog.java
@@ -334,7 +334,8 @@ public final class MapillaryMainDialog extends ToggleDialog implements ICachedLo
           this.thumbnailCache.cancelOutstandingTasks();
         this.thumbnailCache = new MapillaryCache(mapillaryImage.getKey(), MapillaryCache.Type.THUMBNAIL);
         try {
-          this.thumbnailCache.submit(this, false);
+          if (this.thumbnailCache.get() == null)
+            this.thumbnailCache.submit(this, false);
         } catch (IOException e) {
           Logging.error(e);
         }
@@ -345,7 +346,8 @@ public final class MapillaryMainDialog extends ToggleDialog implements ICachedLo
             this.imageCache.cancelOutstandingTasks();
           this.imageCache = new MapillaryCache(mapillaryImage.getKey(), MapillaryCache.Type.FULL_IMAGE);
           try {
-            this.imageCache.submit(this, false);
+            if (this.imageCache.get() == null)
+              this.imageCache.submit(this, false);
           } catch (IOException e) {
             Logging.error(e);
           }


### PR DESCRIPTION
This fixes #72 (pre-fetching does work, but the code forced a download
anyway)

Signed-off-by: Taylor Smock <taylor.smock@kaart.com>