### PR TITLE
Image Viewers for normal and panoramic images

### DIFF
--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryAbstractImage.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryAbstractImage.java
@@ -56,6 +56,8 @@ public abstract class MapillaryAbstractImage extends GpxImageEntry {
   private LatLon tempLatLon;
 
   private final boolean pano;
+  /** Clockwise rotation from initial direction of 360 panoramic images */
+  private double panoTheta;
 
   /**
    * When the object is being dragged in the map, the temporal position is
@@ -357,6 +359,18 @@ public abstract class MapillaryAbstractImage extends GpxImageEntry {
     this.reviewed = reviewed;
   }
 
+  /**
+   * Rotate 360 image's point of view.
+   * @param theta
+   */
+  public void rotatePano(double theta) {
+    this.panoTheta += theta;
+  }
+
+  public double getTheta() {
+    return this.panoTheta;
+  }
+
   public abstract Color paintHighlightedAngleColour();
 
   public abstract Color paintSelectedAngleColour();
@@ -390,6 +404,11 @@ public abstract class MapillaryAbstractImage extends GpxImageEntry {
   }
 
   public void setMovingCa(double ca) {
+    if (ca > 360) {
+      ca = ca - 360;
+    } else if (ca < 0) {
+      ca = ca + 360;
+    }
     this.movingCa = ca;
   }
 

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryData.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryData.java
@@ -508,7 +508,7 @@ public class MapillaryData implements Data {
         fullyDownloadedDetections.add(i);
       });
       if (imagesToGet.contains(getSelectedImage())) {
-        MapillaryMainDialog.getInstance().mapillaryImageDisplay
+        MapillaryMainDialog.getInstance().imageViewer
           .setAllDetections(((MapillaryImage) getSelectedImage()).getDetections());
       }
     }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/ImageColorPicker.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/ImageColorPicker.java
@@ -1,0 +1,263 @@
+// License: GPL. For details, see LICENSE file.
+package org.openstreetmap.josm.plugins.mapillary.gui;
+
+import static org.openstreetmap.josm.tools.I18n.tr;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Point;
+import java.awt.Shape;
+import java.awt.datatransfer.StringSelection;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.awt.event.MouseMotionListener;
+import java.awt.geom.Arc2D;
+import java.awt.geom.Area;
+import java.awt.geom.Ellipse2D;
+import java.awt.image.BufferedImage;
+import javax.swing.BorderFactory;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JToggleButton;
+import javax.swing.SwingUtilities;
+import org.openstreetmap.josm.plugins.mapillary.gui.boilerplate.MapillaryButton;
+import org.openstreetmap.josm.plugins.mapillary.gui.imageinfo.ClipboardAction;
+import org.openstreetmap.josm.plugins.mapillary.gui.imageviewer.AbstractImageViewer;
+import org.openstreetmap.josm.plugins.mapillary.gui.imageviewer.MapillaryImageViewer;
+import org.openstreetmap.josm.plugins.mapillary.gui.imageviewer.PanoramicImageViewer;
+import static org.openstreetmap.josm.tools.ColorHelper.color2html;
+import org.openstreetmap.josm.tools.GBC;
+import org.openstreetmap.josm.tools.ImageProvider;
+
+/**
+ * UI to get color code from image.
+ *
+ * @author Kishan
+ */
+public class ImageColorPicker extends JPanel {
+
+  private AbstractImageViewer imageViewer;
+  private final JPanel colorPanel;
+  private final JPanel tempColorPanel;
+  private Color color;
+  private Color tempColor;
+  private static int colorArea = 150;
+  private final ClipboardAction copyAction;
+  private final JLabel colorLabel;
+  private EyeDropper eyeDropper;
+  private boolean mouseIsDragging = false;
+  private Point pointInComponent;
+  private JToggleButton eyeDropperButton;
+
+  public ImageColorPicker() {
+    setupImageViewer();
+
+    colorLabel = new JLabel(tr("No color selected"));
+    colorPanel = new JPanel();
+    colorPanel.setBorder(BorderFactory.createLineBorder(Color.BLACK));
+    tempColorPanel = new JPanel();
+    tempColorPanel.setBorder(BorderFactory.createLineBorder(Color.BLACK));
+    colorPanel.setPreferredSize(new Dimension(colorArea, colorArea));
+    tempColorPanel.setPreferredSize(new Dimension(colorArea, colorArea));
+
+    copyAction = new ClipboardAction(tr("Copy color"), tr("Copied color to clipboard"), null);
+    final MapillaryButton copyButton = new MapillaryButton(copyAction, true);
+    copyAction.setPopupParent(copyButton);
+
+    color = new Color(0, 0, 0);
+
+    setupEyeDropperButton();
+
+    JPanel panel = new JPanel(new GridBagLayout());
+
+    panel.add(new JLabel(tr("Color")), GBC.eol());
+    panel.add(colorPanel, GBC.std().insets(5).anchor(GridBagConstraints.LINE_START));
+    panel.add(tempColorPanel, GBC.eol().insets(5).anchor(GridBagConstraints.LINE_START));
+    panel.add(colorLabel, GBC.std().anchor(GridBagConstraints.LINE_START));
+    panel.add(copyButton, GBC.eol().anchor(GridBagConstraints.LINE_START));
+    panel.add(eyeDropperButton, GBC.std().anchor(GridBagConstraints.LINE_END));
+
+    setLayout(new GridBagLayout());
+    add(imageViewer, GBC.std().insets(5).weight(1, 1).fill());
+    add(panel, GBC.eol().insets(5));
+  }
+
+  protected void setColor(Color color, Color tempColor, Point p) {
+    this.color = color;
+    this.tempColor = tempColor;
+    colorLabel.setText(color2html(color, false));
+    copyAction.setContents(new StringSelection(color2html(color, false)));
+    colorPanel.setBackground(color);
+    tempColorPanel.setBackground(tempColor);
+    pointInComponent = p;
+  }
+
+  public void addEyeDropper() {
+    if (imageViewer != null) {
+      imageViewer.disableZoomPan();
+      eyeDropper = new EyeDropper(imageViewer);
+      imageViewer.addMouseListener(eyeDropper);
+      imageViewer.addMouseMotionListener(eyeDropper);
+    }
+  }
+
+  public void removeEyeDropper() {
+    if (imageViewer != null && eyeDropper != null) {
+      imageViewer.removeMouseListener(eyeDropper);
+      imageViewer.removeMouseMotionListener(eyeDropper);
+      imageViewer.enableZoomPan();
+    }
+  }
+
+  private void drawColorIndicator(Graphics2D g, Point p, Color current, Color temp) {
+    int r = 100;
+    int w = r / 5;
+
+    Shape upperOuterArc = new Arc2D.Float(p.x - r, p.y - r, 2 * r, 2 * r, 0, 180, Arc2D.CHORD);
+    Shape upperInnerArc = new Arc2D.Float(p.x - (r - w), p.y - (r - w), 2 * (r - w), 2 * (r - w), 0, 180, Arc2D.CHORD);
+    Area upperRing = new Area(upperOuterArc);
+    upperRing.subtract(new Area(upperInnerArc));
+
+    Shape lowerOuterArc = new Arc2D.Float(p.x - r, p.y - r, 2 * r, 2 * r, 180, 180, Arc2D.CHORD);
+    Shape lowerInnerArc = new Arc2D.Float(p.x - (r - w), p.y - (r - w), 2 * (r - w), 2 * (r - w), 180, 180, Arc2D.CHORD);
+    Area lowerRing = new Area(lowerOuterArc);
+    lowerRing.subtract(new Area(lowerInnerArc));
+
+    Shape outerCircle = new Ellipse2D.Float(p.x - (r + w), p.y - (r + w), 2 * (r + w), 2 * (r + w));
+    Shape innerCircle = new Ellipse2D.Float(p.x - r, p.y - r, 2 * r, 2 * r);
+    Area outerRing = new Area(outerCircle);
+    outerRing.subtract(new Area(innerCircle));
+
+    g.setColor(current);
+    g.fill(upperRing);
+    g.setColor(temp);
+    g.fill(lowerRing);
+    g.setColor(Color.GRAY);
+    g.draw(outerRing);
+    g.fill(outerRing);
+  }
+
+  private void setupImageViewer() {
+    if (MapillaryMainDialog.getInstance().imageViewer instanceof PanoramicImageViewer) {
+      imageViewer = new PanoramicImageViewer(){
+        @Override
+        public void paintComponent(Graphics g) {
+          super.paintComponent(g);
+          if (mouseIsDragging)
+            drawColorIndicator((Graphics2D) g, pointInComponent, color, tempColor);
+        }
+      };
+    } else {
+      imageViewer = new MapillaryImageViewer(){
+        @Override
+        public void paintComponent(Graphics g) {
+          super.paintComponent(g);
+          if (mouseIsDragging)
+            drawColorIndicator((Graphics2D) g, pointInComponent, color, tempColor);
+        }
+      };
+    }
+    imageViewer.setImage(MapillaryMainDialog.getInstance().imageViewer.getImage(), null);
+    imageViewer.setPreferredSize(new Dimension(1000, 1000));
+  }
+
+  private void setupEyeDropperButton() {
+    eyeDropperButton = new JToggleButton(ImageProvider.get("mapillary-eyedropper"));
+    ItemListener itemListener = new ItemListener() {
+      @Override
+      public void itemStateChanged(ItemEvent e) {
+        if (e.getStateChange() == ItemEvent.SELECTED) {
+          addEyeDropper();
+        } else {
+          removeEyeDropper();
+        }
+      }
+    };
+    eyeDropperButton.addItemListener(itemListener);
+  }
+
+  public class EyeDropper implements MouseListener, MouseMotionListener {
+
+    private boolean inWindow = false;
+    private BufferedImage screenShot;
+
+    public EyeDropper(AbstractImageViewer panel) {
+      if (panel != null && panel.getSize().getHeight() > 0 && panel.getSize().getWidth() > 0) {
+        this.screenShot = new BufferedImage(panel.getWidth(), panel.getHeight(), BufferedImage.TYPE_INT_RGB);
+        panel.paint(screenShot.getGraphics());
+      }
+    }
+
+    @Override
+    public void mouseClicked(MouseEvent e) {
+      if (getImage() != null) {
+        Color c = new Color(getImage().getRGB(e.getX(), e.getY()));
+        setColor(c, c, e.getPoint());
+      }
+      repaint();
+    }
+
+    @Override
+    public void mousePressed(MouseEvent e) {
+      if (getImage() != null && SwingUtilities.isLeftMouseButton(e)) {
+        mouseIsDragging = true;
+        Color c = new Color(getImage().getRGB(e.getX(), e.getY()));
+        setColor(c, c, e.getPoint());
+      } else {
+        mouseIsDragging = false;
+      }
+      repaint();
+    }
+
+    @Override
+    public void mouseReleased(MouseEvent e) {
+      if (getImage() != null && SwingUtilities.isLeftMouseButton(e)) {
+        if (inWindow && mouseIsDragging) {
+          setColor(tempColor, tempColor, e.getPoint());
+        }
+        mouseIsDragging = false;
+      }
+      repaint();
+    }
+
+    @Override
+    public void mouseEntered(MouseEvent e) {
+      inWindow = true;
+    }
+
+    @Override
+    public void mouseExited(MouseEvent e) {
+      inWindow = false;
+    }
+
+    @Override
+    public void mouseDragged(MouseEvent e) {
+      if (getImage() != null && SwingUtilities.isLeftMouseButton(e)) {
+        if (inWindow) {
+          mouseIsDragging = true;
+          Color c = new Color(getImage().getRGB(e.getX(), e.getY()));
+          setColor(color, c, e.getPoint());
+        } else {
+          mouseIsDragging = false;
+          return;
+        }
+      }
+      repaint();
+    }
+
+    @Override
+    public void mouseMoved(MouseEvent e) {
+      //Do Nothing.
+    }
+
+    private BufferedImage getImage() {
+      return screenShot;
+    }
+  }
+}

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryMainDialog.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/MapillaryMainDialog.java
@@ -422,24 +422,24 @@ public final class MapillaryMainDialog extends ToggleDialog implements ICachedLo
   public void setDisplayImage(BufferedImage image, Collection<ImageDetection> detections, Boolean pano) {
     if (image != null) {
       if (pano) {
-        if (imageViewer == mapillaryViewer) {
+        if (imageViewer instanceof MapillaryImageViewer) {
           panel.remove(imageViewer);
           imageViewer = panoramicViewer;
           panel.add(imageViewer);
+          repaint();
         }
-        imageViewer.setImage(image, detections);
       } else {
-        if (imageViewer == panoramicViewer) {
+        if (imageViewer instanceof PanoramicImageViewer) {
           panel.remove(imageViewer);
           imageViewer = mapillaryViewer;
           panel.add(imageViewer);
+          repaint();
         }
-        imageViewer.setImage(image, detections);
       }
+      imageViewer.setImage(image, detections);
     } else {
       imageViewer.setImage(null, null);
     }
-    repaint();
   }
 
   /**

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/changeset/DeleteSequenceAction.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/changeset/DeleteSequenceAction.java
@@ -60,7 +60,7 @@ public class DeleteSequenceAction extends AbstractAction {
       } else {
         for (MapillaryAbstractImage img : seq.getImages()) {
           if (img instanceof MapillaryImage) {
-            ((MapillaryImage) img).unmarkDeleted();
+            ((MapillaryImage) img).markDeleted();
           }
         }
       }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/dialog/MapillaryFilterDialog.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/dialog/MapillaryFilterDialog.java
@@ -216,6 +216,7 @@ public final class MapillaryFilterDialog extends ToggleDialog
     signs.add(this.onlySigns, GBC.std().anchor(GridBagConstraints.LINE_START));
     signs.add(signChooserPanel, GBC.eol().anchor(GridBagConstraints.LINE_START));
     panel.add(signs, GBC.eol().anchor(GridBagConstraints.LINE_START));
+    panel.add(onlyPano, GBC.eol().anchor(GridBagConstraints.LINE_START));
 
     panel.add(new JSeparator(), GBC.eol().fill(GridBagConstraints.HORIZONTAL));
     objectFilter = new TrafficSignFilter();

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageinfo/ImageInfoPanel.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageinfo/ImageInfoPanel.java
@@ -9,11 +9,13 @@ import java.awt.GridBagLayout;
 import java.awt.Image;
 import java.awt.Insets;
 import java.awt.datatransfer.StringSelection;
+import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.awt.image.BufferedImage;
 import java.net.URL;
 import java.util.Collection;
 import java.util.Optional;
+import javax.swing.AbstractAction;
 
 import javax.swing.ImageIcon;
 import javax.swing.JCheckBox;
@@ -25,16 +27,20 @@ import org.openstreetmap.josm.data.osm.DataSelectionListener;
 import org.openstreetmap.josm.data.osm.OsmPrimitive;
 import org.openstreetmap.josm.data.osm.Tag;
 import org.openstreetmap.josm.data.preferences.AbstractProperty.ValueChangeListener;
+import org.openstreetmap.josm.gui.ExtendedDialog;
 import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.dialogs.ToggleDialog;
 import org.openstreetmap.josm.plugins.mapillary.MapillaryAbstractImage;
 import org.openstreetmap.josm.plugins.mapillary.MapillaryDataListener;
+import org.openstreetmap.josm.plugins.mapillary.gui.ImageColorPicker;
 import org.openstreetmap.josm.plugins.mapillary.MapillaryImage;
 import org.openstreetmap.josm.plugins.mapillary.gui.boilerplate.MapillaryButton;
 import org.openstreetmap.josm.plugins.mapillary.gui.boilerplate.SelectableLabel;
 import org.openstreetmap.josm.plugins.mapillary.model.UserProfile;
 import org.openstreetmap.josm.plugins.mapillary.utils.MapillaryProperties;
 import org.openstreetmap.josm.plugins.mapillary.utils.MapillaryURL;
+import static org.openstreetmap.josm.tools.I18n.tr;
+import org.openstreetmap.josm.tools.ImageProvider;
 import org.openstreetmap.josm.tools.Logging;
 import org.openstreetmap.josm.tools.Shortcut;
 
@@ -52,6 +58,7 @@ public final class ImageInfoPanel extends ToggleDialog implements MapillaryDataL
   private final ClipboardAction copyImgKeyAction;
   private final AddTagToPrimitiveAction addMapillaryTagAction;
   private final JTextPane seqKeyValue;
+  private final MapillaryButton colorPickerButton;
 
   private ValueChangeListener<Boolean> imageLinkChangeListener;
   private boolean destroyed;
@@ -104,6 +111,8 @@ public final class ImageInfoPanel extends ToggleDialog implements MapillaryDataL
 
     addMapillaryTagAction = new AddTagToPrimitiveAction(tr("Add Mapillary tag"));
 
+    colorPickerButton = new MapillaryButton(new ColorChooserAction(), true);
+
     JPanel imgKey = new JPanel();
     imgKey.add(imgKeyValue);
     imgKey.add(copyKeyButton);
@@ -111,6 +120,7 @@ public final class ImageInfoPanel extends ToggleDialog implements MapillaryDataL
     imgButtons.add(new MapillaryButton(imgLinkAction, true));
     imgButtons.add(copyUrlButton);
     imgButtons.add(new MapillaryButton(addMapillaryTagAction, true));
+    imgButtons.add(colorPickerButton);
     seqKeyValue = new SelectableLabel();
 
     JPanel root = new JPanel(new GridBagLayout());
@@ -247,6 +257,11 @@ public final class ImageInfoPanel extends ToggleDialog implements MapillaryDataL
     } else {
       seqKeyValue.setText('‹' + tr("sequence has no key") + '›');
     }
+    if (newImage != null) {
+      colorPickerButton.setEnabled(true);
+    } else {
+      colorPickerButton.setEnabled(false);
+    }
   }
   /* (non-Javadoc)
    * @see org.openstreetmap.josm.data.SelectionChangedListener#selectionChanged(java.util.Collection)
@@ -266,5 +281,22 @@ public final class ImageInfoPanel extends ToggleDialog implements MapillaryDataL
       destroyed = true;
     }
     destroyInstance();
+  }
+
+  private static class ColorChooserAction extends AbstractAction {
+
+    private static final long serialVersionUID = 8706299665735930148L;
+
+    ColorChooserAction() {
+      super(tr("Pick Color"), ImageProvider.get("mapillary-eyedropper",
+      ImageProvider.ImageSizes.SMALLICON));
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent arg0) {
+      ExtendedDialog abc = new ExtendedDialog( MainApplication.getMainFrame(), tr("Color Picker"));
+      abc.setContent(new ImageColorPicker());
+      abc.showDialog();
+    }
   }
 }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageviewer/AbstractImageViewer.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageviewer/AbstractImageViewer.java
@@ -1,7 +1,8 @@
 // License: GPL. For details, see LICENSE file.
 package org.openstreetmap.josm.plugins.mapillary.gui.imageviewer;
 
-import static org.openstreetmap.josm.tools.I18n.tr;
+import java.awt.BasicStroke;
+import java.awt.Color;
 
 import java.awt.Dimension;
 import java.awt.Graphics;
@@ -11,12 +12,21 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import javax.swing.JPanel;
+import org.openstreetmap.josm.gui.MainApplication;
+import org.openstreetmap.josm.gui.layer.LayerManager;
 
 import org.openstreetmap.josm.plugins.mapillary.actions.MapillaryDownloadAction;
 import org.openstreetmap.josm.plugins.mapillary.gui.layer.MapillaryLayer;
-import org.openstreetmap.josm.plugins.mapillary.utils.ImageUtil;
+import org.openstreetmap.josm.plugins.mapillary.gui.layer.PointObjectLayer;
+import org.openstreetmap.josm.plugins.mapillary.model.ImageDetection;
 import org.openstreetmap.josm.plugins.mapillary.utils.ImageViewUtil;
+import org.openstreetmap.josm.plugins.mapillary.utils.MapillaryColorScheme;
+import org.openstreetmap.josm.plugins.mapillary.utils.MapillaryProperties;
 import static org.openstreetmap.josm.tools.I18n.tr;
 
 /**
@@ -28,15 +38,57 @@ public abstract class AbstractImageViewer extends JPanel {
   protected BufferedImage image;
   protected BufferedImage displayImage;
   /**
-   * The rectangle (in image coordinates) of the image that is visible. This rectangle is calculated each time the zoom
-   * is modified
+   * The rectangle (in image coordinates) of the image that is visible.
+   * This rectangle is calculated each time the zoom is modified.
    */
   volatile Rectangle visibleRect;
+  protected final Collection<ImageDetection> detections = Collections.synchronizedList(new ArrayList<>());
 
-  public void setImage(BufferedImage image) {
-    synchronized (this) {
+  public AbstractImageViewer() {
+    setOpaque(true);
+    setDarkMode(MapillaryProperties.DARK_MODE.get());
+    MainApplication.getLayerManager().addLayerChangeListener(new LayerManager.LayerChangeListener() {
+      @Override
+      public void layerAdded(LayerManager.LayerAddEvent e) { }
+
+      @Override
+      public void layerRemoving(LayerManager.LayerRemoveEvent e) {
+        if (e.getRemovedLayer() instanceof MapillaryLayer) {
+          setImage(null, Collections.emptyList());
+        }
+      }
+
+      @Override
+      public void layerOrderChanged(LayerManager.LayerOrderChangeEvent e) { }
+    });
+    MapillaryProperties.SHOW_DETECTION_OUTLINES.addListener(it -> repaint());
+    MapillaryProperties.SHOW_DETECTED_SIGNS.addListener(it -> repaint());
+    MapillaryProperties.DARK_MODE.addListener(it -> setDarkMode(it.getProperty().get()));
+  }
+
+  protected void setImage(BufferedImage image) {
       this.image = image;
+  }
+
+  public void setImage(BufferedImage image, Collection<ImageDetection> detections) {
+    synchronized (this) {
+      setImage(image);
+      this.detections.clear();
+      if (detections != null) {
+        this.detections.addAll(detections);
+      }
       this.visibleRect = getDefaultVisibleRect();
+    }
+    repaint();
+  }
+
+  /**
+   * @param detections The detections to set. Triggers a repaint.
+   */
+  public void setAllDetections(List<ImageDetection> detections) {
+    this.detections.clear();
+    if (detections != null) {
+      this.detections.addAll(detections);
     }
     repaint();
   }
@@ -60,14 +112,19 @@ public abstract class AbstractImageViewer extends JPanel {
     super.paintComponent(g);
     final BufferedImage bufferedImage;
     final Rectangle paintVisibleRect;
+    final Collection<ImageDetection> imageDetections;
     synchronized (this) {
       bufferedImage = this.image;
       paintVisibleRect = this.visibleRect;
+      imageDetections = this.detections;
     }
     if (bufferedImage == null) {
       paintNoImage(g);
     } else {
       paintImage(g, bufferedImage, paintVisibleRect);
+      if (!imageDetections.isEmpty()) {
+        paintDetections(g, paintVisibleRect);
+      }
     }
   }
 
@@ -84,8 +141,9 @@ public abstract class AbstractImageViewer extends JPanel {
   }
 
   public void paintLoadingImage() {
-    if (getGraphics() != null)
+    if (getGraphics() != null) {
       paintLoadingImage(getGraphics());
+    }
   }
 
   private void paintLoadingImage(Graphics g) {
@@ -111,6 +169,19 @@ public abstract class AbstractImageViewer extends JPanel {
     }
   }
 
+  private void paintDetections(Graphics g, Rectangle visibleRect) {
+    if (g instanceof Graphics2D) {
+      final Graphics2D g2d = (Graphics2D) g;
+      g2d.setStroke(new BasicStroke(2));
+      List<PointObjectLayer> detectionLayers = MainApplication.getLayerManager().getLayersOfType(PointObjectLayer.class);
+      synchronized (detections) {
+        paintDetections(g2d, visibleRect, detectionLayers);
+      }
+    }
+  }
+
+  protected abstract void paintDetections(Graphics2D g2d, Rectangle visibleRect, List<PointObjectLayer> detectionLayers);
+
   protected void checkAspectRatio(Rectangle zoomedRectangle) {
     int hFact = zoomedRectangle.height * getSize().width;
     int wFact = zoomedRectangle.width * getSize().height;
@@ -118,15 +189,6 @@ public abstract class AbstractImageViewer extends JPanel {
       zoomedRectangle.width = hFact / getSize().height;
     } else {
       zoomedRectangle.height = wFact / getSize().width;
-    }
-  }
-
-  protected static void checkVisibleRectSize(Image image, Rectangle visibleRect) {
-    if (visibleRect.width > image.getWidth(null)) {
-      visibleRect.width = image.getWidth(null);
-    }
-    if (visibleRect.height > image.getHeight(null)) {
-      visibleRect.height = image.getHeight(null);
     }
   }
 
@@ -140,18 +202,19 @@ public abstract class AbstractImageViewer extends JPanel {
       zoomImage = this.image;
       zoomVisibleRect = this.visibleRect;
     }
-    if (zoomImage == null)
+    if (zoomImage == null) {
       return;
+    }
     if (zoomVisibleRect.width != zoomImage.getWidth(null)
-        || zoomVisibleRect.height != zoomImage.getHeight(null)) {
+      || zoomVisibleRect.height != zoomImage.getHeight(null)) {
       // The display is not at best fit. => Zoom to best fit
       zoomVisibleRect = new Rectangle(0, 0, zoomImage.getWidth(null),
-          zoomImage.getHeight(null));
+        zoomImage.getHeight(null));
     } else {
       // The display is at best fit => zoom to 1:1
       Point center = getCenterImgCoord(zoomVisibleRect);
       zoomVisibleRect = new Rectangle(center.x - getWidth() / 2, center.y
-          - getHeight() / 2, getWidth(), getHeight());
+        - getHeight() / 2, getWidth(), getHeight());
       ImageViewUtil.checkVisibleRectPos(zoomImage, zoomVisibleRect);
     }
     synchronized (this) {
@@ -167,24 +230,61 @@ public abstract class AbstractImageViewer extends JPanel {
   protected Point comp2imgCoord(Rectangle visibleRect, int xComp, int yComp) {
     Rectangle drawRect = calculateDrawImageRectangle(visibleRect);
     return new Point(
-            visibleRect.x + ((xComp - drawRect.x) * visibleRect.width) / drawRect.width,
-            visibleRect.y + ((yComp - drawRect.y) * visibleRect.height) / drawRect.height
+      visibleRect.x + ((xComp - drawRect.x) * visibleRect.width) / drawRect.width,
+      visibleRect.y + ((yComp - drawRect.y) * visibleRect.height) / drawRect.height
     );
+  }
+
+  protected Point img2compCoord(Rectangle visibleRect, int xImg, int yImg) {
+    Rectangle drawRect = calculateDrawImageRectangle(visibleRect);
+    return new Point(drawRect.x + ((xImg - visibleRect.x) * drawRect.width)
+      / visibleRect.width, drawRect.y
+      + ((yImg - visibleRect.y) * drawRect.height) / visibleRect.height);
   }
 
   protected Rectangle calculateDrawImageRectangle(Rectangle visibleRect) {
     return ImageViewUtil.calculateDrawImageRectangle(visibleRect, new Rectangle(0, 0, getSize().width, getSize().height));
   }
 
-  abstract void paintImage(Graphics g, BufferedImage image, Rectangle visibleRect);
+  private void setDarkMode(final boolean darkMode) {
+    setBackground(darkMode ? MapillaryColorScheme.TOOLBAR_DARK_GREY : getBackground());
+    setForeground(darkMode ? Color.LIGHT_GRAY : getForeground());
+  }
 
-  public abstract void zoomOut(int zoomCenterX, int zoomCenterY);
+  /**
+   * Check that the Zoom is not greater than 2:1
+   *
+   * @param zoomedRectangle
+   */
+  protected void checkZoom(Rectangle zoomedRectangle) {
+    if (zoomedRectangle.width < getSize().width / 2) {
+      zoomedRectangle.width = getSize().width / 2;
+    }
+    if (zoomedRectangle.height < getSize().height / 2) {
+      zoomedRectangle.height = getSize().height / 2;
+    }
+  }
 
-  public abstract void zoomIn(int zoomCenterX, int zoomCenterY);
+  protected abstract void paintImage(Graphics g, BufferedImage image, Rectangle visibleRect);
 
+  /**
+   * Method for zooming.
+   * @param zoomCenterX The x coordinate in component where zoomed
+   * @param zoomCenterY The y coordinate in component where zoomed
+   * @param zoomedIn true if zoomed inwards else false
+   */
+  public abstract void zoom(int zoomCenterX, int zoomCenterY, boolean zoomedIn);
+
+  /**
+   * Start dragging Image.
+   * @param p The point in component.
+   */
   public abstract void startPanning(Point p);
 
+  /**
+   * Drag Image to this point
+   * @param p The point in component.
+   */
   public abstract void pan(Point p);
 
-  public abstract void stopPanning();
 }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageviewer/AbstractImageViewer.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageviewer/AbstractImageViewer.java
@@ -297,4 +297,21 @@ public abstract class AbstractImageViewer extends JPanel {
 
   public abstract void viewSizeChanged();
 
+  public void enableZoomPan() {
+    if (!zoomPanEnabled) {
+      addMouseListener(zoomPanMouseListener);
+      addMouseWheelListener(zoomPanMouseListener);
+      addMouseMotionListener(zoomPanMouseListener);
+      zoomPanEnabled = true;
+    }
+  }
+
+  public void disableZoomPan() {
+    if (zoomPanEnabled) {
+      removeMouseListener(zoomPanMouseListener);
+      removeMouseWheelListener(zoomPanMouseListener);
+      removeMouseMotionListener(zoomPanMouseListener);
+      zoomPanEnabled = false;
+    }
+  }
 }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageviewer/AbstractImageViewer.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageviewer/AbstractImageViewer.java
@@ -43,8 +43,16 @@ public abstract class AbstractImageViewer extends JPanel {
    */
   volatile Rectangle visibleRect;
   protected final Collection<ImageDetection> detections = Collections.synchronizedList(new ArrayList<>());
+  private final ZoomPanMouseListener zoomPanMouseListener;
+  private boolean zoomPanEnabled;
 
   public AbstractImageViewer() {
+    zoomPanMouseListener = new ZoomPanMouseListener(this);
+    addMouseListener(zoomPanMouseListener);
+    addMouseWheelListener(zoomPanMouseListener);
+    addMouseMotionListener(zoomPanMouseListener);
+    zoomPanEnabled = true;
+
     setOpaque(true);
     setDarkMode(MapillaryProperties.DARK_MODE.get());
     MainApplication.getLayerManager().addLayerChangeListener(new LayerManager.LayerChangeListener() {
@@ -286,5 +294,7 @@ public abstract class AbstractImageViewer extends JPanel {
    * @param p The point in component.
    */
   public abstract void pan(Point p);
+
+  public abstract void viewSizeChanged();
 
 }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageviewer/AbstractImageViewer.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageviewer/AbstractImageViewer.java
@@ -1,0 +1,190 @@
+// License: GPL. For details, see LICENSE file.
+package org.openstreetmap.josm.plugins.mapillary.gui.imageviewer;
+
+import static org.openstreetmap.josm.tools.I18n.tr;
+
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+import javax.swing.JPanel;
+
+import org.openstreetmap.josm.plugins.mapillary.actions.MapillaryDownloadAction;
+import org.openstreetmap.josm.plugins.mapillary.gui.layer.MapillaryLayer;
+import org.openstreetmap.josm.plugins.mapillary.utils.ImageUtil;
+import org.openstreetmap.josm.plugins.mapillary.utils.ImageViewUtil;
+import static org.openstreetmap.josm.tools.I18n.tr;
+
+/**
+ *
+ * @author Kishan
+ */
+public abstract class AbstractImageViewer extends JPanel {
+
+  protected BufferedImage image;
+  protected BufferedImage displayImage;
+  /**
+   * The rectangle (in image coordinates) of the image that is visible. This rectangle is calculated each time the zoom
+   * is modified
+   */
+  volatile Rectangle visibleRect;
+
+  public void setImage(BufferedImage image) {
+    synchronized (this) {
+      this.image = image;
+      this.visibleRect = getDefaultVisibleRect();
+    }
+    repaint();
+  }
+
+  public abstract Rectangle getDefaultVisibleRect();
+
+  /**
+   * Returns the picture that is being displayed
+   *
+   * @return The picture that is being displayed.
+   */
+  public BufferedImage getImage() {
+    return this.image;
+  }
+
+  /**
+   * Paints the visible part of the picture.
+   */
+  @Override
+  public void paintComponent(Graphics g) {
+    super.paintComponent(g);
+    final BufferedImage bufferedImage;
+    final Rectangle paintVisibleRect;
+    synchronized (this) {
+      bufferedImage = this.image;
+      paintVisibleRect = this.visibleRect;
+    }
+    if (bufferedImage == null) {
+      paintNoImage(g);
+    } else {
+      paintImage(g, bufferedImage, paintVisibleRect);
+    }
+  }
+
+  private void paintNoImage(Graphics g) {
+    final String noImageStr = MapillaryLayer.hasInstance() ? tr("no image selected") : tr("Press \"{0}\" to download images", MapillaryDownloadAction.SHORTCUT.getKeyText());
+    if (noImageStr != null) {
+      Rectangle2D noImageSize = g.getFontMetrics(g.getFont()).getStringBounds(noImageStr, g);
+      Dimension size = getSize();
+      g.setColor(getForeground());
+      g.drawString(noImageStr,
+        (int) ((size.width - noImageSize.getWidth()) / 2),
+        (int) ((size.height - noImageSize.getHeight()) / 2));
+    }
+  }
+
+  public void paintLoadingImage() {
+    if (getGraphics() != null)
+      paintLoadingImage(getGraphics());
+  }
+
+  private void paintLoadingImage(Graphics g) {
+    final String noImageStr = tr("loading image");
+    Rectangle2D noImageSize = g.getFontMetrics().getStringBounds(noImageStr, g);
+    Dimension size = getSize();
+    int llx = (int) ((size.width - noImageSize.getWidth()) / 2);
+    int lly = (int) ((size.height - noImageSize.getHeight()) / 2);
+    if (g instanceof Graphics2D) {
+      Graphics2D g2d = (Graphics2D) g;
+      int height = g2d.getFontMetrics().getHeight();
+      int descender = g2d.getFontMetrics().getDescent();
+      g2d.setColor(getBackground());
+      int width = (int) (noImageSize.getWidth() * 1);
+      int tlx = (int) ((size.getWidth() - noImageSize.getWidth()) / 2);
+      int tly = (int) ((size.getHeight() - 3 * noImageSize.getHeight()) / 2 + descender);
+      g2d.fillRect(tlx, tly, width, height);
+      g2d.setColor(getForeground());
+      g2d.drawString(noImageStr, llx, lly);
+    } else {
+      g.setColor(getForeground());
+      g.drawString(noImageStr, llx, lly);
+    }
+  }
+
+  protected void checkAspectRatio(Rectangle zoomedRectangle) {
+    int hFact = zoomedRectangle.height * getSize().width;
+    int wFact = zoomedRectangle.width * getSize().height;
+    if (hFact > wFact) {
+      zoomedRectangle.width = hFact / getSize().height;
+    } else {
+      zoomedRectangle.height = wFact / getSize().width;
+    }
+  }
+
+  protected static void checkVisibleRectSize(Image image, Rectangle visibleRect) {
+    if (visibleRect.width > image.getWidth(null)) {
+      visibleRect.width = image.getWidth(null);
+    }
+    if (visibleRect.height > image.getHeight(null)) {
+      visibleRect.height = image.getHeight(null);
+    }
+  }
+
+  /**
+   * Zooms to 1:1 and, if it is already in 1:1, to best fit.
+   */
+  public void zoomBestFitOrOne() {
+    Image zoomImage;
+    Rectangle zoomVisibleRect;
+    synchronized (this) {
+      zoomImage = this.image;
+      zoomVisibleRect = this.visibleRect;
+    }
+    if (zoomImage == null)
+      return;
+    if (zoomVisibleRect.width != zoomImage.getWidth(null)
+        || zoomVisibleRect.height != zoomImage.getHeight(null)) {
+      // The display is not at best fit. => Zoom to best fit
+      zoomVisibleRect = new Rectangle(0, 0, zoomImage.getWidth(null),
+          zoomImage.getHeight(null));
+    } else {
+      // The display is at best fit => zoom to 1:1
+      Point center = getCenterImgCoord(zoomVisibleRect);
+      zoomVisibleRect = new Rectangle(center.x - getWidth() / 2, center.y
+          - getHeight() / 2, getWidth(), getHeight());
+      ImageViewUtil.checkVisibleRectPos(zoomImage, zoomVisibleRect);
+    }
+    synchronized (this) {
+      this.visibleRect = zoomVisibleRect;
+    }
+    repaint();
+  }
+
+  protected static Point getCenterImgCoord(Rectangle visibleRect) {
+    return new Point(visibleRect.x + visibleRect.width / 2, visibleRect.y + visibleRect.height / 2);
+  }
+
+  protected Point comp2imgCoord(Rectangle visibleRect, int xComp, int yComp) {
+    Rectangle drawRect = calculateDrawImageRectangle(visibleRect);
+    return new Point(
+            visibleRect.x + ((xComp - drawRect.x) * visibleRect.width) / drawRect.width,
+            visibleRect.y + ((yComp - drawRect.y) * visibleRect.height) / drawRect.height
+    );
+  }
+
+  protected Rectangle calculateDrawImageRectangle(Rectangle visibleRect) {
+    return ImageViewUtil.calculateDrawImageRectangle(visibleRect, new Rectangle(0, 0, getSize().width, getSize().height));
+  }
+
+  abstract void paintImage(Graphics g, BufferedImage image, Rectangle visibleRect);
+
+  public abstract void zoomOut(int zoomCenterX, int zoomCenterY);
+
+  public abstract void zoomIn(int zoomCenterX, int zoomCenterY);
+
+  public abstract void startPanning(Point p);
+
+  public abstract void pan(Point p);
+
+  public abstract void stopPanning();
+}

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageviewer/MapillaryImageViewer.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageviewer/MapillaryImageViewer.java
@@ -23,14 +23,9 @@ import static org.openstreetmap.josm.plugins.mapillary.utils.MapillaryUtils.chec
 public class MapillaryImageViewer extends AbstractImageViewer {
 
   private Point mousePointInImg;
-  public ZoomPanMouseListener zoomPanMouseListener;
 
   public MapillaryImageViewer() {
     super();
-    zoomPanMouseListener = new ZoomPanMouseListener(this);
-    addMouseListener(zoomPanMouseListener);
-    addMouseWheelListener(zoomPanMouseListener);
-    addMouseMotionListener(zoomPanMouseListener);
   }
 
   @Override
@@ -140,6 +135,14 @@ public class MapillaryImageViewer extends AbstractImageViewer {
         g2d.drawImage(MapObject.getIcon(d.getValue()).getImage(), bounds.x, bounds.y, bounds.width, bounds.height,
           null);
       }
+    }
+  }
+
+  @Override
+  public void viewSizeChanged() {
+    if (getImage() != null) {
+      checkAspectRatio(visibleRect);
+      ImageViewUtil.checkVisibleRectSize(image, visibleRect);
     }
   }
 

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageviewer/MapillaryImageViewer.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageviewer/MapillaryImageViewer.java
@@ -1,0 +1,153 @@
+// License: GPL. For details, see LICENSE file.
+package org.openstreetmap.josm.plugins.mapillary.gui.imageviewer;
+
+import java.awt.Component;
+import java.awt.Graphics;
+import java.awt.Image;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
+import java.awt.image.BufferedImage;
+import org.openstreetmap.josm.plugins.mapillary.utils.ImageViewUtil;
+
+public class MapillaryImageViewer extends AbstractImageViewer {
+
+  private Point mousePointInImg;
+
+  public MapillaryImageViewer() {
+    super();
+    ZoomPanMouseListener zoomPanMouseListener = new ZoomPanMouseListener(this);
+    this.addMouseListener(zoomPanMouseListener);
+    this.addMouseWheelListener(zoomPanMouseListener);
+    this.addMouseMotionListener(zoomPanMouseListener);
+  }
+
+  @Override
+  public Rectangle getDefaultVisibleRect() {
+    if (image != null) {
+      Rectangle visibleRectangle = new Rectangle(0, 0, image.getWidth(), image.getHeight());
+      return visibleRectangle;
+    }
+    return visibleRect;
+  }
+
+  @Override
+  void paintImage(Graphics g, BufferedImage image, Rectangle visibleRect) {
+    Rectangle target = ImageViewUtil.calculateDrawImageRectangle(visibleRect,
+      new Rectangle(0, 0, getSize().width, getSize().height));
+    g.drawImage(image, target.x, target.y, target.x + target.width,
+      target.y + target.height, visibleRect.x, visibleRect.y,
+      visibleRect.x + visibleRect.width, visibleRect.y + visibleRect.height, this);
+  }
+
+  @Override
+  public void zoomOut(int zoomCenterX, int zoomCenterY) {
+    Image mouseImage;
+    Rectangle mouseVisibleRect;
+    synchronized (this) {
+      mouseImage = getImage();
+      mouseVisibleRect = this.visibleRect;
+    }
+    if (mouseImage == null) {
+      return;
+    }
+    mousePointInImg = comp2imgCoord(mouseVisibleRect, zoomCenterX, zoomCenterY);
+    mouseVisibleRect.width = mouseVisibleRect.width * 3 / 2;
+    mouseVisibleRect.height = mouseVisibleRect.height * 3 / 2;
+    checkZoom(mouseVisibleRect);
+    checkAspectRatio(mouseVisibleRect);
+    checkVisibleRectSize(mouseImage, mouseVisibleRect);
+    Rectangle drawRect = calculateDrawImageRectangle(mouseVisibleRect);
+    mouseVisibleRect.x = mousePointInImg.x
+      + ((drawRect.x - zoomCenterX) * mouseVisibleRect.width) / drawRect.width;
+    mouseVisibleRect.y = mousePointInImg.y
+      + ((drawRect.y - zoomCenterY) * mouseVisibleRect.height) / drawRect.height;
+    ImageViewUtil.checkVisibleRectPos(mouseImage, mouseVisibleRect);
+    synchronized (this) {
+      visibleRect = mouseVisibleRect;
+    }
+    repaint();
+  }
+
+  @Override
+  public void zoomIn(int zoomCenterX, int zoomCenterY) {
+    Image mouseImage;
+    Rectangle mouseVisibleRect;
+    synchronized (this) {
+      mouseImage = getImage();
+      mouseVisibleRect = this.visibleRect;
+    }
+    if (mouseImage == null) {
+      return;
+    }
+    mousePointInImg = comp2imgCoord(mouseVisibleRect, zoomCenterX, zoomCenterY);
+    mouseVisibleRect.width = mouseVisibleRect.width * 2 / 3;
+    mouseVisibleRect.height = mouseVisibleRect.height * 2 / 3;
+    checkZoom(mouseVisibleRect);
+    checkAspectRatio(mouseVisibleRect);
+    checkVisibleRectSize(mouseImage, mouseVisibleRect);
+    Rectangle drawRect = calculateDrawImageRectangle(mouseVisibleRect);
+    mouseVisibleRect.x = mousePointInImg.x
+      + ((drawRect.x - zoomCenterX) * mouseVisibleRect.width) / drawRect.width;
+    mouseVisibleRect.y = mousePointInImg.y
+      + ((drawRect.y - zoomCenterY) * mouseVisibleRect.height) / drawRect.height;
+    ImageViewUtil.checkVisibleRectPos(mouseImage, mouseVisibleRect);
+    synchronized (this) {
+      visibleRect = mouseVisibleRect;
+    }
+    repaint();
+  }
+
+  @Override
+  public void startPanning(Point p) {
+    if (getImage() == null) {
+      return;
+    }
+    Rectangle mouseVisibleRect;
+    synchronized (this) {
+      mouseVisibleRect = visibleRect;
+    }
+    mousePointInImg = comp2imgCoord(mouseVisibleRect, p.x, p.y);
+  }
+
+  @Override
+  public void pan(Point p) {
+    Image mouseImage;
+    Rectangle mouseVisibleRect;
+    synchronized (this) {
+      mouseImage = getImage();
+      mouseVisibleRect = visibleRect;
+    }
+    if (mouseImage == null) {
+      return;
+    }
+    Point newImagePoint = comp2imgCoord(mouseVisibleRect, p.x, p.y);
+    mouseVisibleRect.x += this.mousePointInImg.x - newImagePoint.x;
+    mouseVisibleRect.y += this.mousePointInImg.y - newImagePoint.y;
+    ImageViewUtil.checkVisibleRectPos(mouseImage, mouseVisibleRect);
+    synchronized (this) {
+      visibleRect = mouseVisibleRect;
+    }
+    repaint();
+  }
+
+  @Override
+  public void stopPanning() {
+    //Do Nothing.
+  }
+
+  /**
+   * Check that the Zoom is not greater than 3:1
+   *
+   * @param zoomedRectangle
+   */
+  protected void checkZoom(Rectangle zoomedRectangle) {
+    if (zoomedRectangle.width < getSize().width / 3) {
+      zoomedRectangle.width = getSize().width / 3;
+    }
+    if (zoomedRectangle.height < getSize().height / 3) {
+      zoomedRectangle.height = getSize().height / 3;
+    }
+  }
+}

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageviewer/MapillaryImageViewer.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageviewer/MapillaryImageViewer.java
@@ -23,7 +23,7 @@ import static org.openstreetmap.josm.plugins.mapillary.utils.MapillaryUtils.chec
 public class MapillaryImageViewer extends AbstractImageViewer {
 
   private Point mousePointInImg;
-  ZoomPanMouseListener zoomPanMouseListener;
+  public ZoomPanMouseListener zoomPanMouseListener;
 
   public MapillaryImageViewer() {
     super();

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageviewer/PanoramicImageViewer.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageviewer/PanoramicImageViewer.java
@@ -38,7 +38,7 @@ public class PanoramicImageViewer extends AbstractImageViewer {
    * See {@link CameraPlane#mapping}.
    */
   static final int imageType = BufferedImage.TYPE_INT_RGB;
-  ZoomPanMouseListener zoomPanMouseListener;
+  public ZoomPanMouseListener zoomPanMouseListener;
 
   public PanoramicImageViewer() {
     super();

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageviewer/PanoramicImageViewer.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageviewer/PanoramicImageViewer.java
@@ -38,14 +38,9 @@ public class PanoramicImageViewer extends AbstractImageViewer {
    * See {@link CameraPlane#mapping}.
    */
   static final int imageType = BufferedImage.TYPE_INT_RGB;
-  public ZoomPanMouseListener zoomPanMouseListener;
 
   public PanoramicImageViewer() {
     super();
-    zoomPanMouseListener = new ZoomPanMouseListener(this);
-    addMouseListener(zoomPanMouseListener);
-    addMouseWheelListener(zoomPanMouseListener);
-    addMouseMotionListener(zoomPanMouseListener);
     addComponentListener(new ComponentSizeListener());
   }
 
@@ -198,6 +193,30 @@ public class PanoramicImageViewer extends AbstractImageViewer {
     return false;
   }
 
+  @Override
+  public void viewSizeChanged() {
+    int width = getWidth();
+    int height = getHeight();
+    /*
+           for performance issues
+           if (width * height > Math.pow(10, 6)) {
+           double scaleFactor = Math.sqrt(Math.pow(10, 6) / (width * height));
+           width = (int) Math.round(width * scaleFactor);
+           height = (int) Math.round(height * scaleFactor);
+           }
+     */
+    offscreenImage = new BufferedImage(width, height,
+      imageType);
+    double cameraPlaneDistance = (width / 2d) / Math.tan(PANORAMA_FOV / 2);
+    cameraPlane = new CameraPlane(width, height,
+      cameraPlaneDistance);
+    if (getImage() != null) {
+      checkZoom(visibleRect);
+      checkAspectRatio(visibleRect);
+      ImageViewUtil.checkVisibleRectSize(offscreenImage, visibleRect);
+    }
+  }
+
   protected static class ComponentSizeListener extends ComponentAdapter {
 
     @Override
@@ -205,26 +224,7 @@ public class PanoramicImageViewer extends AbstractImageViewer {
       final Component component = e.getComponent();
       if (component instanceof PanoramicImageViewer) {
         final PanoramicImageViewer imgDisplay = (PanoramicImageViewer) component;
-        int width = imgDisplay.getWidth();
-        int height = imgDisplay.getHeight();
-        /*
-           for performance issues
-           if (width * height > Math.pow(10, 6)) {
-           double scaleFactor = Math.sqrt(Math.pow(10, 6) / (width * height));
-           width = (int) Math.round(width * scaleFactor);
-           height = (int) Math.round(height * scaleFactor);
-           }
-         */
-        imgDisplay.offscreenImage = new BufferedImage(width, height,
-          imageType);
-        double cameraPlaneDistance = (width / 2d) / Math.tan(PANORAMA_FOV / 2);
-        imgDisplay.cameraPlane = new CameraPlane(width, height,
-          cameraPlaneDistance);
-        if (imgDisplay.getImage() != null) {
-          imgDisplay.checkZoom(imgDisplay.visibleRect);
-          imgDisplay.checkAspectRatio(imgDisplay.visibleRect);
-          ImageViewUtil.checkVisibleRectSize(imgDisplay.offscreenImage, imgDisplay.visibleRect);
-        }
+        imgDisplay.viewSizeChanged();
       }
     }
   }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageviewer/PanoramicImageViewer.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageviewer/PanoramicImageViewer.java
@@ -190,8 +190,8 @@ public class PanoramicImageViewer extends AbstractImageViewer {
   }
 
   private boolean validMousePoint(Point p) {
-    if (0 < p.x && p.x < offscreenImage.getWidth()) {
-      if (0 < p.y && p.y < offscreenImage.getHeight()) {
+    if (0 <= p.x && p.x < offscreenImage.getWidth()) {
+      if (0 <= p.y && p.y < offscreenImage.getHeight()) {
         return true;
       }
     }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageviewer/PanoramicImageViewer.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageviewer/PanoramicImageViewer.java
@@ -34,7 +34,7 @@ public class PanoramicImageViewer extends AbstractImageViewer {
   private Point mousePointInImg;
   static final double PANORAMA_FOV = Math.toRadians(110);
   /**
-   * Use INT_RGB for faster image mapping 
+   * Use INT_RGB for faster image mapping
    * See {@link CameraPlane#mapping}.
    */
   static final int imageType = BufferedImage.TYPE_INT_RGB;
@@ -151,13 +151,11 @@ public class PanoramicImageViewer extends AbstractImageViewer {
       return;
     }
     Point newImagePoint = comp2imgCoord(mouseVisibleRect, p.x, p.y);
-    if (validMousePoint(newImagePoint)) {
-      cameraPlane.setRotationFromDelta(mousePointInImg, newImagePoint);
-      mousePointInImg = newImagePoint;
-    }
+    ImageViewUtil.checkPointInRect(newImagePoint, mouseVisibleRect);
+    cameraPlane.setRotationFromDelta(mousePointInImg, newImagePoint);
+    mousePointInImg = newImagePoint;
     repaint();
   }
-
 
   @Override
   protected void paintDetections(Graphics2D g2d, Rectangle visibleRect, List<PointObjectLayer> detectionLayers) {

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageviewer/PanoramicImageViewer.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageviewer/PanoramicImageViewer.java
@@ -1,0 +1,233 @@
+// License: GPL. For details, see LICENSE file.
+package org.openstreetmap.josm.plugins.mapillary.gui.imageviewer;
+
+import java.awt.Component;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
+import java.awt.geom.PathIterator;
+import java.awt.image.BufferedImage;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.openstreetmap.josm.plugins.mapillary.gui.layer.PointObjectLayer;
+import org.openstreetmap.josm.plugins.mapillary.gui.panorama.CameraPlane;
+import org.openstreetmap.josm.plugins.mapillary.gui.panorama.UVMapping;
+import org.openstreetmap.josm.plugins.mapillary.model.ImageDetection;
+import org.openstreetmap.josm.plugins.mapillary.utils.ImageViewUtil;
+import static org.openstreetmap.josm.plugins.mapillary.utils.MapillaryUtils.checkIfDetectionIsFiltered;
+
+/**
+ * Image viewer for Panoramic Images.
+ * @author Kishan
+ */
+public class PanoramicImageViewer extends AbstractImageViewer {
+
+  private BufferedImage offscreenImage;
+  /**
+   * 360-degree panorama photo projection class.
+   */
+  private CameraPlane cameraPlane;
+  private Point mousePointInImg;
+  static final double PANORAMA_FOV = Math.toRadians(110);
+  /**
+   * Use INT_RGB for faster image mapping 
+   * See {@link CameraPlane#mapping}.
+   */
+  static final int imageType = BufferedImage.TYPE_INT_RGB;
+  ZoomPanMouseListener zoomPanMouseListener;
+
+  public PanoramicImageViewer() {
+    super();
+    zoomPanMouseListener = new ZoomPanMouseListener(this);
+    addMouseListener(zoomPanMouseListener);
+    addMouseWheelListener(zoomPanMouseListener);
+    addMouseMotionListener(zoomPanMouseListener);
+    addComponentListener(new ComponentSizeListener());
+  }
+
+  @Override
+  public Rectangle getDefaultVisibleRect() {
+    if (image != null) {
+      Rectangle visibleRectangle = new Rectangle(0, 0, getWidth(), getHeight());
+      return visibleRectangle;
+    }
+    return visibleRect;
+  }
+
+  /**
+   * Change image to type {@link BufferedImage#TYPE_INT_RGB} for faster image mapping.
+   * See {@link CameraPlane#mapping}.
+   */
+  @Override
+  protected void setImage(BufferedImage image) {
+    if (image != null) {
+      BufferedImage newImage = new BufferedImage(image.getWidth(),
+        image.getHeight(), imageType);
+      Graphics2D g = newImage.createGraphics();
+      g.drawImage(image, 0, 0, null);
+      g.dispose();
+      super.setImage(newImage);
+    } else {
+      super.setImage(image);
+    }
+  }
+
+  @Override
+  protected void paintImage(Graphics g, BufferedImage image, Rectangle visibleRect) {
+    final Rectangle target;
+    if (cameraPlane == null) {
+      double cameraPlaneDistance = (getWidth() / 2d) / Math.tan(PANORAMA_FOV / 2);
+      cameraPlane = new CameraPlane(this.getWidth(), getHeight(), cameraPlaneDistance);
+    }
+    if (offscreenImage == null) {
+      offscreenImage = new BufferedImage(getWidth(), getHeight(), imageType);
+    }
+    cameraPlane.mapping(image, offscreenImage);
+    target = new Rectangle(0, 0, getWidth(), getHeight());
+    g.drawImage(offscreenImage, target.x, target.y, target.x + target.width, target.y
+      + target.height, visibleRect.x, visibleRect.y, visibleRect.x
+      + visibleRect.width, visibleRect.y + visibleRect.height, null);
+  }
+
+  @Override
+  public void zoom(int zoomCenterX, int zoomCenterY, boolean zoomedIn) {
+    Image mouseImage;
+    Rectangle mouseVisibleRect;
+    synchronized (this) {
+      mouseImage = getImage();
+      mouseVisibleRect = this.visibleRect;
+    }
+    if (mouseImage == null) {
+      return;
+    }
+    mousePointInImg = comp2imgCoord(mouseVisibleRect, zoomCenterX, zoomCenterY);
+    if (zoomedIn) {
+      mouseVisibleRect.width = mouseVisibleRect.width * 2 / 3;
+      mouseVisibleRect.height = mouseVisibleRect.height * 2 / 3;
+    } else {
+      mouseVisibleRect.width = mouseVisibleRect.width * 3 / 2;
+      mouseVisibleRect.height = mouseVisibleRect.height * 3 / 2;
+    }
+    checkZoom(mouseVisibleRect);
+    checkAspectRatio(mouseVisibleRect);
+    ImageViewUtil.checkVisibleRectSize(offscreenImage, mouseVisibleRect);
+    Rectangle drawRect = calculateDrawImageRectangle(mouseVisibleRect);
+    mouseVisibleRect.x = mousePointInImg.x
+      + ((drawRect.x - zoomCenterX) * mouseVisibleRect.width) / drawRect.width;
+    mouseVisibleRect.y = mousePointInImg.y
+      + ((drawRect.y - zoomCenterY) * mouseVisibleRect.height) / drawRect.height;
+    ImageViewUtil.checkVisibleRectPos(offscreenImage, mouseVisibleRect);
+    synchronized (this) {
+      visibleRect = mouseVisibleRect;
+    }
+    repaint();
+  }
+
+  @Override
+  public void startPanning(Point p) {
+    if (getImage() == null) {
+      return;
+    }
+    Rectangle mouseVisibleRect;
+    synchronized (this) {
+      mouseVisibleRect = visibleRect;
+    }
+    mousePointInImg = comp2imgCoord(mouseVisibleRect, p.x, p.y);
+  }
+
+  @Override
+  public void pan(Point p) {
+    Image mouseImage;
+    Rectangle mouseVisibleRect;
+    synchronized (this) {
+      mouseImage = getImage();
+      mouseVisibleRect = visibleRect;
+    }
+    if (mouseImage == null) {
+      return;
+    }
+    Point newImagePoint = comp2imgCoord(mouseVisibleRect, p.x, p.y);
+    if (validMousePoint(newImagePoint)) {
+      cameraPlane.setRotationFromDelta(mousePointInImg, newImagePoint);
+      mousePointInImg = newImagePoint;
+    }
+    repaint();
+  }
+
+
+  @Override
+  protected void paintDetections(Graphics2D g2d, Rectangle visibleRect, List<PointObjectLayer> detectionLayers) {
+    List<ImageDetection> paintDetections = detections.parallelStream()
+      .filter(d -> !checkIfDetectionIsFiltered(detectionLayers, d)).collect(Collectors.toList());
+    for (final ImageDetection d : paintDetections) {
+      g2d.setColor(d.getColor());
+      final PathIterator pathIt = d.getShape().getPathIterator(null);
+      Point prevPoint = null;
+      while (!pathIt.isDone()) {
+        final double[] buffer = new double[6];
+        final int segmentType = pathIt.currentSegment(buffer);
+
+        if (segmentType == PathIterator.SEG_LINETO || segmentType == PathIterator.SEG_QUADTO
+          || segmentType == PathIterator.SEG_CUBICTO) {
+          // Takes advantage of the fact that SEG_LINETO=1, SEG_QUADTO=2, SEG_CUBICTO=3 and currentSegment() returns 1,
+          // 2 and 3 points for each of these segment types
+          final Point curPoint = cameraPlane
+            .getPoint(UVMapping.getVector(buffer[2 * (segmentType - 1)], buffer[2 * (segmentType - 1) + 1]));
+          if (prevPoint != null && curPoint != null) {
+            g2d.drawLine(prevPoint.x, prevPoint.y, curPoint.x, curPoint.y);
+          }
+          prevPoint = curPoint;
+        } else if (segmentType == PathIterator.SEG_MOVETO) {
+          prevPoint = cameraPlane.getPoint(UVMapping.getVector(buffer[0], buffer[1]));
+        } else {
+          prevPoint = null;
+        }
+        pathIt.next();
+      }
+    }
+  }
+
+  private boolean validMousePoint(Point p) {
+    if (0 < p.x && p.x < offscreenImage.getWidth()) {
+      if (0 < p.y && p.y < offscreenImage.getHeight()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  protected static class ComponentSizeListener extends ComponentAdapter {
+
+    @Override
+    public void componentResized(ComponentEvent e) {
+      final Component component = e.getComponent();
+      if (component instanceof PanoramicImageViewer) {
+        final PanoramicImageViewer imgDisplay = (PanoramicImageViewer) component;
+        int width = imgDisplay.getWidth();
+        int height = imgDisplay.getHeight();
+        /*
+           for performance issues
+           if (width * height > Math.pow(10, 6)) {
+           double scaleFactor = Math.sqrt(Math.pow(10, 6) / (width * height));
+           width = (int) Math.round(width * scaleFactor);
+           height = (int) Math.round(height * scaleFactor);
+           }
+         */
+        imgDisplay.offscreenImage = new BufferedImage(width, height,
+          imageType);
+        double cameraPlaneDistance = (width / 2d) / Math.tan(PANORAMA_FOV / 2);
+        imgDisplay.cameraPlane = new CameraPlane(width, height,
+          cameraPlaneDistance);
+        if (imgDisplay.getImage() != null) {
+          imgDisplay.checkZoom(imgDisplay.visibleRect);
+          imgDisplay.checkAspectRatio(imgDisplay.visibleRect);
+          ImageViewUtil.checkVisibleRectSize(imgDisplay.offscreenImage, imgDisplay.visibleRect);
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageviewer/PanoramicImageViewer.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageviewer/PanoramicImageViewer.java
@@ -38,6 +38,7 @@ public class PanoramicImageViewer extends AbstractImageViewer {
    * See {@link CameraPlane#mapping}.
    */
   static final int imageType = BufferedImage.TYPE_INT_RGB;
+  private boolean mappingChanged = true;
 
   public PanoramicImageViewer() {
     super();
@@ -81,7 +82,10 @@ public class PanoramicImageViewer extends AbstractImageViewer {
     if (offscreenImage == null) {
       offscreenImage = new BufferedImage(getWidth(), getHeight(), imageType);
     }
-    cameraPlane.mapping(image, offscreenImage);
+    if (mappingChanged) {
+      cameraPlane.mapping(image, offscreenImage);
+      mappingChanged = false;
+    }
     target = new Rectangle(0, 0, getWidth(), getHeight());
     g.drawImage(offscreenImage, target.x, target.y, target.x + target.width, target.y
       + target.height, visibleRect.x, visibleRect.y, visibleRect.x
@@ -148,6 +152,7 @@ public class PanoramicImageViewer extends AbstractImageViewer {
     Point newImagePoint = comp2imgCoord(mouseVisibleRect, p.x, p.y);
     ImageViewUtil.checkPointInRect(newImagePoint, mouseVisibleRect);
     cameraPlane.setRotationFromDelta(mousePointInImg, newImagePoint);
+    mappingChanged = true;
     mousePointInImg = newImagePoint;
     repaint();
   }
@@ -208,8 +213,8 @@ public class PanoramicImageViewer extends AbstractImageViewer {
     offscreenImage = new BufferedImage(width, height,
       imageType);
     double cameraPlaneDistance = (width / 2d) / Math.tan(PANORAMA_FOV / 2);
-    cameraPlane = new CameraPlane(width, height,
-      cameraPlaneDistance);
+    cameraPlane = new CameraPlane(width, height, cameraPlaneDistance);
+    mappingChanged = true;
     if (getImage() != null) {
       checkZoom(visibleRect);
       checkAspectRatio(visibleRect);

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageviewer/ZoomPanMouseListener.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageviewer/ZoomPanMouseListener.java
@@ -1,0 +1,100 @@
+// License: GPL. For details, see LICENSE file.
+package org.openstreetmap.josm.plugins.mapillary.gui.imageviewer;
+
+import java.awt.Point;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.awt.event.MouseMotionListener;
+import java.awt.event.MouseWheelEvent;
+import java.awt.event.MouseWheelListener;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
+import javax.swing.SwingUtilities;
+
+/**
+ *
+ * @author Kishan
+ */
+public class ZoomPanMouseListener implements MouseListener, MouseWheelListener, MouseMotionListener {
+
+  protected boolean isZooming = false;
+  protected boolean isPanning = false;
+  private final AbstractImageViewer imageViewer;
+  protected boolean inWindow = false;
+
+  public ZoomPanMouseListener(AbstractImageViewer imageViewer) {
+    this.imageViewer = imageViewer;
+  }
+
+  public void reset() {
+    isZooming = false;
+    isPanning = false;
+  }
+
+  public void stopPanning() {
+    isPanning = false;
+    imageViewer.stopPanning();
+  }
+
+  @Override
+  public void mouseClicked(MouseEvent e) {
+    if (!SwingUtilities.isLeftMouseButton(e)) {
+      return;
+    }
+    if (e.getClickCount() == 2) {
+      imageViewer.zoomBestFitOrOne();
+    }
+  }
+
+  @Override
+  public void mousePressed(MouseEvent e) {
+    if (!isPanning && SwingUtilities.isLeftMouseButton(e)) {
+      isPanning = true;
+      imageViewer.startPanning(e.getPoint());
+    }
+  }
+
+  @Override
+  public void mouseReleased(MouseEvent e) {
+    if (isPanning && SwingUtilities.isLeftMouseButton(e)) {
+      stopPanning();
+    }
+  }
+
+  @Override
+  public void mouseEntered(MouseEvent e) {
+    inWindow = true;
+  }
+
+  @Override
+  public void mouseExited(MouseEvent e) {
+    inWindow = false;
+  }
+
+  @Override
+  public void mouseWheelMoved(MouseWheelEvent e) {
+    if (isPanning || !inWindow) {
+      return;
+    }
+    if (e.getWheelRotation() < 0) {
+      imageViewer.zoomIn(e.getX(), e.getY());
+    } else {
+      imageViewer.zoomOut(e.getX(), e.getY());
+    }
+  }
+
+  @Override
+  public void mouseDragged(MouseEvent e) {
+    if (SwingUtilities.isLeftMouseButton(e)) {
+      if (isPanning) {
+        imageViewer.pan(e.getPoint());
+      }
+    }
+  }
+
+  @Override
+  public void mouseMoved(MouseEvent e) {
+    //Do nothing.
+  }
+
+}

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageviewer/ZoomPanMouseListener.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/imageviewer/ZoomPanMouseListener.java
@@ -1,18 +1,16 @@
 // License: GPL. For details, see LICENSE file.
 package org.openstreetmap.josm.plugins.mapillary.gui.imageviewer;
 
-import java.awt.Point;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
 import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;
-import java.awt.geom.AffineTransform;
-import java.awt.geom.Point2D;
 import javax.swing.SwingUtilities;
+import org.openstreetmap.josm.plugins.mapillary.utils.MapillaryProperties;
 
 /**
- *
+ * MouseListener for zooming and dragging images.
  * @author Kishan
  */
 public class ZoomPanMouseListener implements MouseListener, MouseWheelListener, MouseMotionListener {
@@ -33,12 +31,11 @@ public class ZoomPanMouseListener implements MouseListener, MouseWheelListener, 
 
   public void stopPanning() {
     isPanning = false;
-    imageViewer.stopPanning();
   }
 
   @Override
   public void mouseClicked(MouseEvent e) {
-    if (!SwingUtilities.isLeftMouseButton(e)) {
+    if (e.getButton() != MapillaryProperties.PICTURE_OPTION_BUTTON.get()) {
       return;
     }
     if (e.getClickCount() == 2) {
@@ -48,7 +45,8 @@ public class ZoomPanMouseListener implements MouseListener, MouseWheelListener, 
 
   @Override
   public void mousePressed(MouseEvent e) {
-    if (!isPanning && SwingUtilities.isLeftMouseButton(e)) {
+    if (!isPanning &&
+      (e.getButton() == MapillaryProperties.PICTURE_DRAG_BUTTON.get())) {
       isPanning = true;
       imageViewer.startPanning(e.getPoint());
     }
@@ -56,7 +54,8 @@ public class ZoomPanMouseListener implements MouseListener, MouseWheelListener, 
 
   @Override
   public void mouseReleased(MouseEvent e) {
-    if (isPanning && SwingUtilities.isLeftMouseButton(e)) {
+    if (isPanning &&
+      (e.getButton() == MapillaryProperties.PICTURE_DRAG_BUTTON.get())) {
       stopPanning();
     }
   }
@@ -73,19 +72,19 @@ public class ZoomPanMouseListener implements MouseListener, MouseWheelListener, 
 
   @Override
   public void mouseWheelMoved(MouseWheelEvent e) {
-    if (isPanning || !inWindow) {
+    if (isPanning) {
       return;
     }
     if (e.getWheelRotation() < 0) {
-      imageViewer.zoomIn(e.getX(), e.getY());
+      imageViewer.zoom(e.getX(), e.getY(), true);
     } else {
-      imageViewer.zoomOut(e.getX(), e.getY());
+      imageViewer.zoom(e.getX(), e.getY(), false);
     }
   }
 
   @Override
   public void mouseDragged(MouseEvent e) {
-    if (SwingUtilities.isLeftMouseButton(e)) {
+    if (SwingUtilities.isRightMouseButton(e)) {
       if (isPanning) {
         imageViewer.pan(e.getPoint());
       }
@@ -96,5 +95,4 @@ public class ZoomPanMouseListener implements MouseListener, MouseWheelListener, 
   public void mouseMoved(MouseEvent e) {
     //Do nothing.
   }
-
 }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/layer/MapillaryLayer.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/layer/MapillaryLayer.java
@@ -176,7 +176,7 @@ public final class MapillaryLayer extends AbstractModifiableLayer implements
       MapillaryMainDialog.getInstance().showDialog();
     }
     if (MapillaryPlugin.getMapView() != null) {
-      MapillaryMainDialog.getInstance().mapillaryImageDisplay.repaint();
+      MapillaryMainDialog.getInstance().imageViewer.repaint();
       MapillaryMainDialog.getInstance()
         .getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
         .put(KeyStroke.getKeyStroke("DELETE"), "MapillaryDel");

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/layer/PointObjectLayer.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/layer/PointObjectLayer.java
@@ -328,7 +328,7 @@ public class PointObjectLayer extends AbstractOsmDataLayer
         mapillaryData.setSelectedImage(toSelect);
       }
     }
-    SwingUtilities.invokeLater(() -> MapillaryMainDialog.getInstance().mapillaryImageDisplay.repaint());
+    SwingUtilities.invokeLater(() -> MapillaryMainDialog.getInstance().imageViewer.repaint());
   }
 
   @Override

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/panorama/CameraPlane.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/panorama/CameraPlane.java
@@ -13,6 +13,8 @@ import org.apache.commons.math3.geometry.euclidean.threed.RotationConvention;
 import org.apache.commons.math3.geometry.euclidean.threed.RotationOrder;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 import org.apache.commons.math3.util.FastMath;
+import org.openstreetmap.josm.plugins.mapillary.gui.MapillaryMainDialog;
+import org.openstreetmap.josm.plugins.mapillary.gui.layer.MapillaryLayer;
 
 import org.openstreetmap.josm.tools.Logging;
 
@@ -37,6 +39,9 @@ public class CameraPlane {
     this.width = width;
     this.height = height;
     this.distance = distance;
+    if (MapillaryMainDialog.getInstance().getImage() != null) {
+      this.theta = MapillaryMainDialog.getInstance().getImage().getTheta();
+    }
     rotation = new Rotation(RotationOrder.XYX, RotationConvention.VECTOR_OPERATOR, 0, 0, 0);
     setRotation(0.0, 0.0);
     vectors = new Vector3D[width][height];
@@ -95,6 +100,10 @@ public class CameraPlane {
       double deltaPhi = FastMath.atan2(f1.getY(), FastMath.sqrt(f1.getX() * f1.getX() + f1.getZ() * f1.getZ()))
           - FastMath.atan2(t1.getY(), FastMath.sqrt(t1.getX() * t1.getX() + t1.getZ() * t1.getZ()));
       double newTheta = theta + deltaTheta;
+      if (MapillaryMainDialog.getInstance().getImage() != null) {
+        MapillaryMainDialog.getInstance().getImage().rotatePano(FastMath.toDegrees(deltaTheta));
+      }
+      MapillaryLayer.invalidateInstance();
       // Prevent flipping the 360 viewer accidentally
       double newPhi = Math.max(Math.min(phi + deltaPhi, HALF_PI), -HALF_PI);
       setRotation(newTheta, newPhi);

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/download/DetectionsDownloadRunnable.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/download/DetectionsDownloadRunnable.java
@@ -77,7 +77,7 @@ public class DetectionsDownloadRunnable extends BoundsDownloadRunnable {
       if (image instanceof MapillaryImage) {
         MapillaryImage mapillaryImage = (MapillaryImage) image;
         if (detections.containsKey(mapillaryImage.getKey())) {
-          MapillaryMainDialog.getInstance().mapillaryImageDisplay.repaint();
+          MapillaryMainDialog.getInstance().imageViewer.repaint();
         }
       }
       completed = Boolean.TRUE;

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/ImageUtil.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/ImageUtil.java
@@ -1,7 +1,13 @@
 // License: GPL. For details, see LICENSE file.
 package org.openstreetmap.josm.plugins.mapillary.utils;
 
+import java.awt.Graphics2D;
 import java.awt.Image;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.geom.AffineTransform;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
 
 import javax.swing.ImageIcon;
 
@@ -26,5 +32,15 @@ public final class ImageUtil {
       icon.getIconHeight() >= icon.getIconWidth() ? size : Math.max(1, Math.round(icon.getIconHeight() / (float) icon.getIconWidth() * size)),
       Image.SCALE_SMOOTH
     ));
+  }
+
+  public static BufferedImage scale(BufferedImage src, int width, int height) {
+    BufferedImage dest = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+    Graphics2D g = dest.createGraphics();
+    AffineTransform at = AffineTransform.getScaleInstance(
+      (double) width / src.getWidth(),
+      (double) height / src.getHeight());
+    g.drawRenderedImage(src, at);
+    return dest;
   }
 }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/ImageUtil.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/ImageUtil.java
@@ -3,11 +3,8 @@ package org.openstreetmap.josm.plugins.mapillary.utils;
 
 import java.awt.Graphics2D;
 import java.awt.Image;
-import java.awt.Point;
-import java.awt.Rectangle;
 import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
-import java.io.IOException;
 
 import javax.swing.ImageIcon;
 

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/ImageViewUtil.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/ImageViewUtil.java
@@ -2,11 +2,12 @@
 package org.openstreetmap.josm.plugins.mapillary.utils;
 
 import java.awt.Image;
+import java.awt.Point;
 import java.awt.Rectangle;
 
 public final class ImageViewUtil {
   private ImageViewUtil() {
-    
+
   }
 
   public static void checkVisibleRectPos(Image image, Rectangle visibleRect) {
@@ -56,6 +57,21 @@ public final class ImageViewUtil {
     }
     if (visibleRect.height > image.getHeight(null)) {
       visibleRect.height = image.getHeight(null);
+    }
+  }
+
+  public static void checkPointInRect(Point p, Rectangle rect) {
+    if (p.x < rect.x) {
+      p.x = rect.x;
+    }
+    if (p.x > rect.x + rect.width) {
+      p.x = rect.x + rect.width -1;
+    }
+    if (p.y < rect.y) {
+      p.y = rect.y;
+    }
+    if (p.y > rect.y + rect.height) {
+      p.y = rect.y + rect.height -1;
     }
   }
 }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/ImageViewUtil.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/ImageViewUtil.java
@@ -62,7 +62,7 @@ public final class ImageViewUtil {
 
   /**
    * Check if the given point is within the given rectangle.
-   * If it is out of bounds then it change it is bought on rectangle's edges.
+   * If it is out of bounds then it change it is brought back to rectangle's edges.
    */
   public static void checkPointInRect(Point p, Rectangle rect) {
     if (p.x < rect.x) {

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/ImageViewUtil.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/ImageViewUtil.java
@@ -1,0 +1,52 @@
+// License: GPL. For details, see LICENSE file.
+package org.openstreetmap.josm.plugins.mapillary.utils;
+
+import java.awt.Image;
+import java.awt.Rectangle;
+
+public final class ImageViewUtil {
+  private ImageViewUtil() {
+    
+  }
+
+  public static void checkVisibleRectPos(Image image, Rectangle visibleRect) {
+    if (visibleRect.x < 0) {
+      visibleRect.x = 0;
+    }
+    if (visibleRect.y < 0) {
+      visibleRect.y = 0;
+    }
+    if (visibleRect.x + visibleRect.width > image.getWidth(null)) {
+      visibleRect.x = image.getWidth(null) - visibleRect.width;
+    }
+    if (visibleRect.y + visibleRect.height > image.getHeight(null)) {
+      visibleRect.y = image.getHeight(null) - visibleRect.height;
+    }
+  }
+
+  /**
+   * calculateDrawImageRectangle
+   *
+   * @param imgRect the part of the image that should be drawn (in image coordinates)
+   * @param compRect the part of the component where the image should be drawn (in component coordinates)
+   * @return the part of compRect with the same width/height ratio as the image
+   */
+  public static Rectangle calculateDrawImageRectangle(Rectangle imgRect, Rectangle compRect) {
+    int x = 0;
+    int y = 0;
+    int w = compRect.width;
+    int h = compRect.height;
+    int wFact = w * imgRect.height;
+    int hFact = h * imgRect.width;
+    if (wFact != hFact) {
+      if (wFact > hFact) {
+        w = hFact / imgRect.height;
+        x = (compRect.width - w) / 2;
+      } else {
+        h = wFact / imgRect.width;
+        y = (compRect.height - h) / 2;
+      }
+    }
+    return new Rectangle(x + compRect.x, y + compRect.y, w, h);
+  }
+}

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/ImageViewUtil.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/ImageViewUtil.java
@@ -60,17 +60,21 @@ public final class ImageViewUtil {
     }
   }
 
+  /**
+   * Check if the given point is within the given rectangle.
+   * If it is out of bounds then it change it is bought on rectangle's edges.
+   */
   public static void checkPointInRect(Point p, Rectangle rect) {
     if (p.x < rect.x) {
       p.x = rect.x;
     }
-    if (p.x > rect.x + rect.width) {
+    if (p.x >= rect.x + rect.width) {
       p.x = rect.x + rect.width -1;
     }
     if (p.y < rect.y) {
       p.y = rect.y;
     }
-    if (p.y > rect.y + rect.height) {
+    if (p.y >= rect.y + rect.height) {
       p.y = rect.y + rect.height -1;
     }
   }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/ImageViewUtil.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/ImageViewUtil.java
@@ -49,4 +49,13 @@ public final class ImageViewUtil {
     }
     return new Rectangle(x + compRect.x, y + compRect.y, w, h);
   }
+
+  public static void checkVisibleRectSize(Image image, Rectangle visibleRect) {
+    if (visibleRect.width > image.getWidth(null)) {
+      visibleRect.width = image.getWidth(null);
+    }
+    if (visibleRect.height > image.getHeight(null)) {
+      visibleRect.height = image.getHeight(null);
+    }
+  }
 }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryUtils.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryUtils.java
@@ -4,6 +4,7 @@ package org.openstreetmap.josm.plugins.mapillary.utils;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
@@ -14,10 +15,13 @@ import org.apache.commons.imaging.formats.tiff.constants.GpsTagConstants;
 
 import org.openstreetmap.josm.data.Bounds;
 import org.openstreetmap.josm.data.coor.LatLon;
+import org.openstreetmap.josm.data.osm.OsmPrimitive;
 import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.plugins.mapillary.MapillaryAbstractImage;
 import org.openstreetmap.josm.plugins.mapillary.MapillarySequence;
 import org.openstreetmap.josm.plugins.mapillary.gui.layer.MapillaryLayer;
+import org.openstreetmap.josm.plugins.mapillary.gui.layer.PointObjectLayer;
+import org.openstreetmap.josm.plugins.mapillary.model.ImageDetection;
 import org.openstreetmap.josm.tools.I18n;
 
 /**
@@ -254,5 +258,18 @@ public final class MapillaryUtils {
       ret.append(" — ").append(PluginState.getUploadString());
     }
     MainApplication.getMap().statusLine.setHelpText(ret.toString());
+  }
+
+  /**
+   * Check if the given ImageDetection is filtered out.
+   */
+  public static boolean checkIfDetectionIsFiltered(final List<PointObjectLayer> detectionLayers, final ImageDetection d) {
+    if ((Boolean.FALSE.equals(MapillaryProperties.SHOW_DETECTION_OUTLINES.get())
+        && !"trafficsigns".contains(d.getPackage()))
+        || (Boolean.FALSE.equals(MapillaryProperties.SHOW_DETECTED_SIGNS.get())
+            && "trafficsigns".contains(d.getPackage())))
+      return true;
+    OsmPrimitive prim = detectionLayers.parallelStream().map(PointObjectLayer::getDataSet).flatMap(data -> data.allPrimitives().parallelStream()).filter(p -> p.hasKey("detections") && p.get("detections").contains(d.getKey())).findAny().orElse(null);
+    return prim != null && prim.isDisabled();
   }
 }

--- a/src/main/resources/images/mapillary-eyedropper.svg
+++ b/src/main/resources/images/mapillary-eyedropper.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22.37 22.36">
+  <g>
+    <g>
+      <path d="M21.52,1.42,21,.86a2.46,2.46,0,0,0-3.46,0L14.16,4.13l4.09,4.09,3.3-3.34A2.46,2.46,0,0,0,21.52,1.42Z" transform="translate(0 -0.02)" stroke="#000" stroke-miterlimit="10" stroke-width="0.25"/>
+      <rect x="13.74" y="2.91" width="2.86" height="8.59" transform="translate(-0.65 12.82) rotate(-45)" stroke="#000" stroke-miterlimit="10" stroke-width="0.25"/>
+    </g>
+    <path d="M12.5,5.83,2,16.32c2.93-.17,5.78-.34,8.46-.36l6.08-6.08Z" transform="translate(0 -0.02)" fill="#fff" stroke="#000" stroke-linejoin="round" stroke-width="0.5"/>
+    <path d="M.35,18l-.1,4.15L4.4,22,10.47,16c-2.68,0-5.53.19-8.46.36Z" transform="translate(0 -0.02)" fill="#009245" stroke="#000" stroke-linejoin="round" stroke-width="0.5"/>
+  </g>
+  <path d="M8.47,8.67" transform="translate(0 -0.02)" fill="none" stroke="#000" stroke-linejoin="round" stroke-width="0.5"/>
+</svg>


### PR DESCRIPTION
- Different Image Viewers for normal and panoramic images.

- Faster Image mapping for panoramic images using `ImageRaster`'s buffer instead of  `Image.getRGB()`.

