### PR TITLE
Remote control

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -37,6 +37,5 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/JOSM"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/JOSM-apache-commons"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/JOSM-apache-http"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/JOSM-javafx"/>
 	<classpathentry kind="output" path="bin/default"/>
 </classpath>

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,11 +6,11 @@ plugin.icon=images/mapillary-logo.svg
 plugin.link=https://wiki.openstreetmap.org/wiki/JOSM/Plugins/Mapillary
 # Minimum required JOSM version to run this plugin, choose the lowest version possible that is compatible.
 # You can check if the plugin compiles against this version by executing `./gradlew compileJava_minJosm`.
-plugin.main.version=17023
+plugin.main.version=17084
 # Version of JOSM against which the plugin is compiled
 # Please check, if the specified version is available for download from https://josm.openstreetmap.de/download/ .
 # If not, choose the next higher number that is available, or the gradle build will break.
-plugin.compile.version=17023
+plugin.compile.version=17084
 # The datepicker plugin is currently in the source tree. TODO fix
 plugin.requires=apache-commons;apache-http
 

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryImage.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryImage.java
@@ -90,10 +90,8 @@ public class MapillaryImage extends MapillaryAbstractImage {
 
   @Override
   public String toString() {
-    return String.format(
-      "Image[key=%s,lat=%f,lon=%f,ca=%f,user=%s,capturedAt=%d]",
-      key, latLon.lat(), latLon.lon(), ca, getUser() == null ? "null" : getUser().getUsername(), capturedAt
-    );
+    return String.format("Image[key=%s,lat=%f,lon=%f,ca=%f,user=%s,capturedAt=%d]", key, getExifCoor().lat(),
+        getExifCoor().lon(), ca, getUser() == null ? "null" : getUser().getUsername(), capturedAt);
   }
 
   @Override
@@ -134,7 +132,7 @@ public class MapillaryImage extends MapillaryAbstractImage {
     if (MapillaryLayer.hasInstance()) {
       MapillaryLayer.getInstance().getDeletionChangeset().add(this);
       isDeleted = Boolean.TRUE;
-      this.setMovingLatLon(latLon);
+      this.setMovingLatLon(getExifCoor());
     }
   }
 

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryImportedImage.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryImportedImage.java
@@ -124,10 +124,8 @@ public class MapillaryImportedImage extends MapillaryAbstractImage {
 
   @Override
   public String toString() {
-    return String.format(
-      "Image[filename=%s,lat=%f,lon=%f,ca=%f,capturedAt=%d]",
-      getFile() == null ? "null" : getFile().getName(), latLon.lat(), latLon.lon(), ca, capturedAt
-    );
+    return String.format("Image[filename=%s,lat=%f,lon=%f,ca=%f,capturedAt=%d]",
+        getFile() == null ? "null" : getFile().getName(), getExifCoor().lat(), getExifCoor().lon(), ca, capturedAt);
   }
 
   @Override

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryKeyListener.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryKeyListener.java
@@ -1,0 +1,108 @@
+// License: GPL. For details, see LICENSE file.
+package org.openstreetmap.josm.plugins.mapillary;
+
+import static org.openstreetmap.josm.tools.I18n.tr;
+
+import java.awt.Component;
+import java.awt.event.ActionEvent;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.swing.AbstractAction;
+import javax.swing.JPopupMenu;
+import javax.swing.event.PopupMenuEvent;
+import javax.swing.event.PopupMenuListener;
+
+import org.openstreetmap.josm.gui.dialogs.properties.PropertiesDialog;
+import org.openstreetmap.josm.gui.util.GuiHelper;
+import org.openstreetmap.josm.plugins.mapillary.gui.layer.MapillaryLayer;
+import org.openstreetmap.josm.plugins.mapillary.io.download.MapillaryDownloader;
+import org.openstreetmap.josm.tools.Destroyable;
+import org.openstreetmap.josm.tools.ImageProvider;
+
+/**
+ * Listen for Mapillary keys
+ *
+ * @author Taylor Smock
+ */
+public class MapillaryKeyListener implements PopupMenuListener, Destroyable {
+
+  private JPopupMenu menu;
+  private PropertiesDialog properties;
+  private Map<JPopupMenu, List<String>> addedValues = new HashMap<>();
+  private Map<JPopupMenu, List<Component>> addedComponents = new HashMap<>();
+
+  public MapillaryKeyListener(PropertiesDialog properties, JPopupMenu menu) {
+    this.menu = menu;
+    this.properties = properties;
+    menu.addPopupMenuListener(this);
+  }
+
+  @Override
+  public void popupMenuWillBecomeVisible(PopupMenuEvent e) {
+    JPopupMenu popup = (JPopupMenu) e.getSource();
+    properties.visitSelectedProperties((primitive, key, value) -> addAction(popup, key, value));
+  }
+
+  @Override
+  public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {
+    JPopupMenu popup = (JPopupMenu) e.getSource();
+    if (addedValues.containsKey(popup) && addedComponents.containsKey(popup)) {
+      addedValues.remove(popup);
+      addedComponents.get(popup).forEach(popup::remove);
+      addedComponents.remove(popup);
+    }
+  }
+
+  @Override
+  public void popupMenuCanceled(PopupMenuEvent e) {
+    // Do nothing
+  }
+
+  private void addAction(JPopupMenu popup, String key, String value) {
+    if ("mapillary".equals(key.toLowerCase(Locale.ROOT)) && MapillaryLayer.hasInstance()) {
+      List<String> strings = addedValues.computeIfAbsent(popup, p -> new ArrayList<>());
+      List<Component> components = addedComponents.computeIfAbsent(popup, p -> new ArrayList<>());
+      if (!strings.contains(value)) {
+        strings.add(value);
+        components.add(popup.add(new MapillaryKeyAction(value)));
+      }
+    }
+  }
+
+  @Override
+  public void destroy() {
+    if (menu != null) {
+      menu.removePopupMenuListener(this);
+    }
+    properties = null;
+    menu = null;
+  }
+
+  private static class MapillaryKeyAction extends AbstractAction {
+    private static final long serialVersionUID = -4129937925620244251L;
+    private String imageKey;
+
+    MapillaryKeyAction(String imageKey) {
+      new ImageProvider("mapillary-logo").getResource().attachImageIcon(this, true);
+      this.imageKey = imageKey;
+      putValue(NAME, tr("Select Mapillary Image ({0})", this.imageKey));
+      putValue(SHORT_DESCRIPTION, tr("Select the Mapillary Image {0} on the {1} layer (downloads if needed)",
+          this.imageKey, MapillaryLayer.getInstance().getName()));
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+      MapillaryData data = MapillaryLayer.getInstance().getData();
+      if (data.getImage(this.imageKey) == null) {
+        MapillaryDownloader.downloadSequences(
+            MapillaryDownloader.downloadImages(this.imageKey.split(";", 0)).keySet().toArray(new String[0]));
+      }
+      GuiHelper.runInEDT(() -> data.setSelectedImage(data.getImage(this.imageKey)));
+    }
+
+  }
+}

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryPlugin.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryPlugin.java
@@ -20,6 +20,7 @@ import org.openstreetmap.josm.gui.MapView;
 import org.openstreetmap.josm.gui.dialogs.ToggleDialog;
 import org.openstreetmap.josm.gui.layer.Layer;
 import org.openstreetmap.josm.gui.preferences.PreferenceSetting;
+import org.openstreetmap.josm.io.remotecontrol.RequestProcessor;
 import org.openstreetmap.josm.plugins.Plugin;
 import org.openstreetmap.josm.plugins.PluginInformation;
 import org.openstreetmap.josm.plugins.mapillary.actions.MapObjectLayerAction;
@@ -44,6 +45,7 @@ import org.openstreetmap.josm.plugins.mapillary.gui.imageinfo.ImageInfoHelpPopup
 import org.openstreetmap.josm.plugins.mapillary.gui.imageinfo.ImageInfoPanel;
 import org.openstreetmap.josm.plugins.mapillary.gui.layer.MapillaryLayer;
 import org.openstreetmap.josm.plugins.mapillary.gui.layer.PointObjectLayer;
+import org.openstreetmap.josm.plugins.mapillary.io.remotecontrol.MapillaryRemoteControl;
 import org.openstreetmap.josm.plugins.mapillary.oauth.MapillaryUser;
 import org.openstreetmap.josm.plugins.mapillary.utils.MapillaryProperties;
 import org.openstreetmap.josm.tools.Destroyable;
@@ -125,6 +127,11 @@ public class MapillaryPlugin extends Plugin implements Destroyable {
     MainMenu.add(menu.imagerySubMenu, mapPointObjectLayerAction, false);
     mapPointObjectLayerAction.updateEnabledState();
     destroyables.add(mapPointObjectLayerAction);
+
+    // TODO remove in destroy (not currently possible)
+    RequestProcessor.addRequestHandlerClass("photo", MapillaryRemoteControl.class);
+    // instantiate to get action into Remote Control Preferences
+    new MapillaryRemoteControl();
 
     mapFrameInitialized(null, MainApplication.getMap());
   }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/ImageCheckBoxButton.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/ImageCheckBoxButton.java
@@ -174,6 +174,16 @@ public class ImageCheckBoxButton extends JPanel implements Destroyable, TableMod
     return null;
   }
 
+  @Override
+  public void setVisible(boolean visible) {
+    super.setVisible(visible);
+  }
+
+  @Override
+  public boolean isVisible() {
+    return super.isVisible();
+  }
+
   /**
    * @return {@code true} if selected (see {@link JCheckBox#isSelected}).
    */

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/dialog/TrafficSignFilter.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/dialog/TrafficSignFilter.java
@@ -113,6 +113,10 @@ public class TrafficSignFilter extends JPanel implements Destroyable {
 
     buttons = new ArrayList<>();
     addButtons();
+
+    if (!showRelevantObjs.isSelected()) {
+      showRelevantObjs.doClick();
+    }
     /* End filter signs */
   }
 
@@ -150,6 +154,11 @@ public class TrafficSignFilter extends JPanel implements Destroyable {
     updateShown(showMaxNumberModel);
   }
 
+  /**
+   * Update the shown buttons
+   *
+   * @param model The model used to paginate the buttons.
+   */
   private void updateShown(SpinnerNumberModel model) {
     buttons.parallelStream().forEach(i -> SwingUtilities.invokeLater(() -> i.setVisible(false)));
     buttons.stream().filter(i -> i.isFiltered(filterField.getText())).skip(
@@ -266,9 +275,15 @@ public class TrafficSignFilter extends JPanel implements Destroyable {
     add(scrollPane, GBC.eol().fill().anchor(GridBagConstraints.WEST));
   }
 
+  /**
+   * Filter buttons (along with a relevancy check).
+   *
+   * @param expr An expression to filter buttons with
+   */
   private void filterButtons(String expr) {
-    SwingUtilities.invokeLater(
-      () -> buttons.stream().forEach(b -> b.setVisible(b.isFiltered(expr) && (!showRelevant || b.isRelevant()))));
+    SwingUtilities.invokeLater(() -> buttons.stream()
+        .forEach(b -> b.setVisible(b.isFiltered(expr) && (!showRelevant || b.isRelevant()))));
+    SwingUtilities.invokeLater(this::invalidate);
   }
 
   public void getIcons(JComponent panel, String type) {

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/history/commands/CommandDelete.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/history/commands/CommandDelete.java
@@ -40,9 +40,8 @@ public class CommandDelete extends MapillaryExecutableCommand {
       this.images.forEach((img) -> {// Get index first so order is preserved
           this.changesHash.put(img, img.getSequence().getImages().indexOf(img));
       });
-      this.images.forEach((img) -> {// Now Delete
-          MapillaryLayer.getInstance().getData().remove(img);
-      });
+      // Same code as redo
+      redo();
   }
 
   @Override
@@ -61,6 +60,7 @@ public class CommandDelete extends MapillaryExecutableCommand {
 
   @Override
   public void redo() {
+    /** This method is called in {@link #execute()}. Please update execute if necessary. */
     MapillaryLayer.getInstance().getData().remove(this.images);
   }
 }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/download/MapillaryDownloader.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/download/MapillaryDownloader.java
@@ -1,11 +1,24 @@
 // License: GPL. For details, see LICENSE file.
 package org.openstreetmap.josm.plugins.mapillary.io.download;
 
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collector;
+
+import javax.json.Json;
+import javax.json.JsonArrayBuilder;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+import javax.json.JsonReader;
+import javax.json.JsonValue;
 
 import org.openstreetmap.josm.data.Bounds;
 import org.openstreetmap.josm.data.DataSource;
@@ -13,19 +26,28 @@ import org.openstreetmap.josm.data.coor.LatLon;
 import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.MapView;
 import org.openstreetmap.josm.gui.Notification;
+import org.openstreetmap.josm.plugins.mapillary.MapillaryAbstractImage;
 import org.openstreetmap.josm.plugins.mapillary.MapillaryPlugin;
+import org.openstreetmap.josm.plugins.mapillary.MapillarySequence;
 import org.openstreetmap.josm.plugins.mapillary.gui.DownloadTableModel;
 import org.openstreetmap.josm.plugins.mapillary.gui.dialog.MapillaryDownloadDialog;
 import org.openstreetmap.josm.plugins.mapillary.gui.layer.MapillaryLayer;
+import org.openstreetmap.josm.plugins.mapillary.oauth.OAuthUtils;
 import org.openstreetmap.josm.plugins.mapillary.utils.MapillaryProperties;
+import org.openstreetmap.josm.plugins.mapillary.utils.MapillaryURL;
 import org.openstreetmap.josm.plugins.mapillary.utils.MapillaryUtils;
+import org.openstreetmap.josm.plugins.mapillary.utils.api.JsonDecoder;
+import org.openstreetmap.josm.plugins.mapillary.utils.api.JsonImageDetailsDecoder;
+import org.openstreetmap.josm.plugins.mapillary.utils.api.JsonSequencesDecoder;
+import org.openstreetmap.josm.tools.HttpClient;
+import org.openstreetmap.josm.tools.HttpClient.Response;
 import org.openstreetmap.josm.tools.I18n;
 import org.openstreetmap.josm.tools.ImageProvider;
 import org.openstreetmap.josm.tools.Logging;
 
 /**
- * Class that concentrates all the ways of downloading of the plugin. All the download petitions will be managed one by
- * one.
+ * Class that concentrates all the ways of downloading of the plugin. All the
+ * download petitions will be managed one by one.
  *
  * @author nokutu
  */
@@ -39,7 +61,7 @@ public final class MapillaryDownloader {
     PRIVATE_ONLY("privateOnly", I18n.marktr("Only download private images")),
     ALL("all", I18n.marktr("Download all available images"));
 
-    public final static PRIVATE_IMAGE_DOWNLOAD_MODE DEFAULT = ALL;
+    public static final PRIVATE_IMAGE_DOWNLOAD_MODE DEFAULT = ALL;
 
     private final String prefId;
     private final String label;
@@ -79,7 +101,7 @@ public final class MapillaryDownloader {
     // i18n: download mode for Mapillary images
     MANUAL_ONLY("manualOnly", I18n.tr("only when manually requested"));
 
-    public final static DOWNLOAD_MODE DEFAULT = OSM_AREA;
+    public static final DOWNLOAD_MODE DEFAULT = OSM_AREA;
 
     private final String prefId;
     private final String label;
@@ -90,7 +112,8 @@ public final class MapillaryDownloader {
     }
 
     /**
-     * @return the ID that is used to represent this download mode in the JOSM preferences
+     * @return the ID that is used to represent this download mode in the JOSM
+     *         preferences
      */
     public String getPrefId() {
       return prefId;
@@ -127,15 +150,19 @@ public final class MapillaryDownloader {
    */
   private static final double MAX_AREA = MapillaryProperties.MAX_DOWNLOAD_AREA.get();
 
+  /** The key for GeoJSON features */
+  private static final String GEOJSON_FEATURES = "features";
+
   /**
    * Executor that will run the petitions.
    */
-  private static ThreadPoolExecutor executor = new ThreadPoolExecutor(
-    3, 5, 100, TimeUnit.SECONDS, new ArrayBlockingQueue<>(100), new ThreadPoolExecutor.DiscardPolicy());
+  private static ThreadPoolExecutor executor = new ThreadPoolExecutor(3, 5, 100, TimeUnit.SECONDS,
+      new ArrayBlockingQueue<>(100), new ThreadPoolExecutor.DiscardPolicy());
 
   /**
-   * Indicates whether the last download request has been rejected because it requested an area that was too big. If
-   * true, the last download has been rejected, if false, it was executed.
+   * Indicates whether the last download request has been rejected because it
+   * requested an area that was too big. If true, the last download has been
+   * rejected, if false, it was executed.
    */
   private static boolean stoppedDownload;
 
@@ -144,8 +171,8 @@ public final class MapillaryDownloader {
   }
 
   /**
-   * Gets all the images in a square. It downloads all the images of all the sequences that pass through the given
-   * rectangle.
+   * Gets all the images in a square. It downloads all the images of all the
+   * sequences that pass through the given rectangle.
    *
    * @param minLatLon The minimum latitude and longitude of the rectangle.
    * @param maxLatLon The maximum latitude and longitude of the rectangle
@@ -166,8 +193,9 @@ public final class MapillaryDownloader {
     try {
       run(new MapillarySquareDownloadRunnable(bounds));
     } catch (RejectedExecutionException e) {
-      new Notification("Download limit reached").setIcon(MapillaryPlugin.LOGO.setSize(ImageProvider.ImageSizes.LARGEICON).get())
-        .setDuration(Notification.TIME_LONG).show();
+      new Notification("Download limit reached")
+          .setIcon(MapillaryPlugin.LOGO.setSize(ImageProvider.ImageSizes.LARGEICON).get())
+          .setDuration(Notification.TIME_LONG).show();
       MapillaryLayer.getInstance().getData().removeDataSource(new DataSource(bounds, bounds.toString()));
     }
   }
@@ -229,6 +257,74 @@ public final class MapillaryDownloader {
   }
 
   /**
+   * Download a specific set of images
+   *
+   * @param images The images to download
+   * @return The downloaded images
+   */
+  public static Map<String, Collection<MapillaryAbstractImage>> downloadImages(String... images) {
+    JsonObject response = getUrlResponse(MapillaryURL.APIv3.getImage(images));
+    return JsonDecoder.decodeFeatureCollection(response, JsonImageDetailsDecoder::decodeImageInfos).stream()
+        .collect(Collector.of(HashMap<String, Collection<MapillaryAbstractImage>>::new,
+            (rMap, oMap) -> rMap.putAll(oMap), (rMap, oMap) -> {
+              rMap.putAll(oMap);
+              return rMap;
+            }));
+  }
+
+  /**
+   * Download a specific set of sequences
+   *
+   * @param sequences The sequences to download
+   * @return The downloaded sequences
+   */
+  public static Collection<MapillarySequence> downloadSequences(String... sequences) {
+    JsonObject response = getUrlResponse(MapillaryURL.APIv3.getSequence(sequences));
+    Collection<MapillarySequence> returnSequences = JsonDecoder.decodeFeatureCollection(response,
+        JsonSequencesDecoder::decodeSequence);
+    JsonObject imageResponse = getUrlResponse(MapillaryURL.APIv3.getImagesBySequences(
+        returnSequences.stream().map(MapillarySequence::getKey).distinct().toArray(String[]::new)));
+    JsonDecoder.decodeFeatureCollection(imageResponse, JsonImageDetailsDecoder::decodeImageInfos);
+    return returnSequences;
+  }
+
+  private static JsonObject getUrlResponse(URL url) {
+    HttpClient client = OAuthUtils.addAuthenticationHeader(HttpClient.create(url));
+    try (JsonReader reader = Json.createReader(client.connect().getContentReader())) {
+      Response response = client.connect();
+      URL next = MapillaryURL.APIv3.parseNextFromLinkHeaderValue(response.getHeaderField("Link"));
+      JsonObject returnObject = reader.readObject();
+      if (next != null && !next.toExternalForm().trim().isEmpty() && !next.equals(url)) {
+        JsonObject nextObject = getUrlResponse(next);
+        if (checkFeaturesIsArray(returnObject) && checkFeaturesIsArray(nextObject)) {
+          JsonArrayBuilder rArray = Json.createArrayBuilder(returnObject.getJsonArray(GEOJSON_FEATURES));
+          rArray.addAll(Json.createArrayBuilder(nextObject.getJsonArray(GEOJSON_FEATURES)));
+          JsonObjectBuilder rBuilder = Json.createObjectBuilder(returnObject);
+          rBuilder.add(GEOJSON_FEATURES, rArray);
+          returnObject = rBuilder.build();
+        }
+      }
+      return returnObject;
+    } catch (IOException e) {
+      Logging.trace(e);
+      return null;
+    } finally {
+      client.disconnect();
+    }
+  }
+
+  /**
+   * Utility method to check that a GeoJSON has a feature array
+   *
+   * @param object The object to check
+   * @return {@code true} if the object has a valid feature array
+   */
+  private static boolean checkFeaturesIsArray(JsonObject object) {
+    return object.containsKey(GEOJSON_FEATURES)
+        && object.get(GEOJSON_FEATURES).getValueType() == JsonValue.ValueType.ARRAY;
+  }
+
+  /**
    * Downloads all images of the area covered by the OSM data.
    */
   public static void downloadOSMArea() {
@@ -279,6 +375,7 @@ public final class MapillaryDownloader {
       executor.awaitTermination(30, TimeUnit.SECONDS);
     } catch (InterruptedException e) {
       Logging.error(e);
+      Thread.currentThread().interrupt();
     }
     executor = new ThreadPoolExecutor(3, 5, 100, TimeUnit.SECONDS,
       new ArrayBlockingQueue<>(100), new ThreadPoolExecutor.DiscardPolicy());

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/download/SequenceDownloadRunnable.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/download/SequenceDownloadRunnable.java
@@ -70,18 +70,14 @@ public final class SequenceDownloadRunnable extends BoundsDownloadRunnable {
       for (MapillarySequence seq : sequences) {
         if (Boolean.TRUE.equals(MapillaryProperties.CUT_OFF_SEQUENCES_AT_BOUNDS.get())) {
           for (MapillaryAbstractImage img : seq.getImages()) {
-            if (bounds.contains(img.getLatLon())) {
+            if (bounds.isCollapsed() || bounds.isOutOfTheWorld() || bounds.contains(img.getLatLon())) {
               data.add(img);
             } else {
               seq.remove(img);
             }
           }
         } else {
-          boolean sequenceCrossesThroughBounds = false;
-          for (int i = 0; i < seq.getImages().size() && !sequenceCrossesThroughBounds; i++) {
-            sequenceCrossesThroughBounds = bounds.contains(seq.getImages().get(i).getLatLon());
-          }
-          if (sequenceCrossesThroughBounds) {
+          if (seq.getImages().stream().anyMatch(image -> bounds.contains(image.getLatLon()))) {
             data.addAll(seq.getImages(), true);
           }
         }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/remotecontrol/MapillaryRemoteControl.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/remotecontrol/MapillaryRemoteControl.java
@@ -1,0 +1,146 @@
+// License: GPL. For details, see LICENSE file.
+package org.openstreetmap.josm.plugins.mapillary.io.remotecontrol;
+
+import static org.openstreetmap.josm.tools.I18n.tr;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.openstreetmap.josm.actions.AutoScaleAction;
+import org.openstreetmap.josm.data.gpx.GpxImageEntry;
+import org.openstreetmap.josm.data.osm.Node;
+import org.openstreetmap.josm.gui.MainApplication;
+import org.openstreetmap.josm.gui.util.GuiHelper;
+import org.openstreetmap.josm.io.remotecontrol.PermissionPrefWithDefault;
+import org.openstreetmap.josm.io.remotecontrol.handler.RequestHandler;
+import org.openstreetmap.josm.plugins.mapillary.MapillaryAbstractImage;
+import org.openstreetmap.josm.plugins.mapillary.gui.layer.MapillaryLayer;
+import org.openstreetmap.josm.plugins.mapillary.io.download.MapillaryDownloader;
+import org.openstreetmap.josm.plugins.mapillary.mode.SelectMode;
+
+/**
+ * Remote Control handler for Mapillary
+ *
+ */
+public class MapillaryRemoteControl extends RequestHandler.RawURLParseRequestHandler {
+  private static final PermissionPrefWithDefault PERMISSION_PREF_WITH_DEFAULT = new PermissionPrefWithDefault(
+    "mapillary.remote_control", true, tr("Mapillary"));
+
+  private static final String IMAGE_STRING = "photo";
+  private static final String SEQUENCE_STRING = "sequence";
+  private static final String MAPILLARY_PREFIX = "Mapillary/";
+
+  private String[] images;
+  private String[] sequences;
+
+  @Override
+  public String[] getMandatoryParams() {
+    return new String[] {};
+  }
+
+  @Override
+  public String[] getOptionalParams() {
+    return new String[] { IMAGE_STRING, SEQUENCE_STRING };
+  }
+
+  @Override
+  public String getPermissionMessage() {
+    final String br = "<br />";
+    StringBuilder sb = new StringBuilder().append(tr("Remote Control has been asked to load:"));
+    if (images != null && Stream.of(images).anyMatch(image -> !image.trim().isEmpty())) {
+      sb.append(br).append(tr("Image: ")).append(String.join(", ", images));
+    }
+    if (sequences != null && Stream.of(sequences).anyMatch(sequence -> !sequence.trim().isEmpty())) {
+      sb.append(br).append(tr("Sequence: ")).append(String.join(", ", sequences));
+    }
+    return sb.toString();
+  }
+
+  @Override
+  public PermissionPrefWithDefault getPermissionPref() {
+    return PERMISSION_PREF_WITH_DEFAULT;
+  }
+
+  @Override
+  public String getUsage() {
+    return tr("downloads street level images (currently supports {0})", "Mapillary");
+  }
+
+  @Override
+  public String[] getUsageExamples() {
+    return new String[] { "/photo", "/photo?photo=Mapillary/t6g8zH8K-00W9S30iCtPaQ",
+      "photo?sequence=Mapillary/VCBzPB-zgE6R4dEpBkseEQ" };
+  }
+
+  @Override
+  protected void handleRequest() throws RequestHandlerErrorException, RequestHandlerBadRequestException {
+    String[] mapillaryImages = Stream.of(images).filter(image -> image.startsWith(MAPILLARY_PREFIX))
+      .map(image -> image.substring(MAPILLARY_PREFIX.length())).toArray(String[]::new);
+    List<String> mapillarySequences = Stream.of(sequences).filter(sequence -> sequence.startsWith(MAPILLARY_PREFIX))
+      .map(sequence -> sequence.substring(MAPILLARY_PREFIX.length()))
+      .collect(Collectors.toCollection(ArrayList::new));
+    if (mapillaryImages.length == 0 && mapillarySequences.isEmpty()) {
+      throw new RequestHandlerBadRequestException(tr("No known image provider used"));
+    }
+    // This will create a mapillary layer if one does not already exist
+    Collection<Node> nodes = new HashSet<>();
+    if (mapillaryImages.length > 0) {
+      Map<String, Collection<MapillaryAbstractImage>> images = GuiHelper
+        .runInEDTAndWaitAndReturn(() -> MapillaryDownloader.downloadImages(mapillaryImages));
+      mapillarySequences.addAll(images.keySet());
+      nodes.addAll(images.entrySet().stream().flatMap(e -> e.getValue().stream()).map(GpxImageEntry::getExifCoor)
+        .filter(Objects::nonNull).map(Node::new).collect(Collectors.toList()));
+      List<MapillaryAbstractImage> addedImages = images.entrySet().stream().flatMap(entry -> entry.getValue().stream())
+        .collect(Collectors.toList());
+      if (addedImages.size() == 1) {
+        GuiHelper.runInEDTAndWait(
+          () -> MapillaryLayer.getInstance().getData().setSelectedImage(addedImages.iterator().next(), true));
+      }
+    }
+    mapillarySequences.removeIf(string -> string.trim().isEmpty());
+    if (!mapillarySequences.isEmpty()) {
+      List<Node> tNodes = GuiHelper.runInEDTAndWaitAndReturn(
+        () -> MapillaryDownloader.downloadSequences(mapillarySequences.stream().toArray(String[]::new)).stream()
+          .flatMap(seq -> seq.getImages().stream()).map(GpxImageEntry::getExifCoor).filter(Objects::nonNull)
+          .map(Node::new).collect(Collectors.toList()));
+      if (nodes.isEmpty()) {
+        nodes.addAll(tNodes);
+      }
+    }
+    nodes.removeIf(Objects::isNull);
+    if (!nodes.isEmpty()) {
+      if (MainApplication.getLayerManager().getLayersOfType(MapillaryLayer.class).isEmpty()) {
+        GuiHelper.runInEDTAndWait(() -> MainApplication.getLayerManager().addLayer(MapillaryLayer.getInstance()));
+        MapillaryLayer.getInstance().setMode(new SelectMode());
+      }
+      GuiHelper.runInEDT(() -> AutoScaleAction.zoomTo(nodes));
+    }
+  }
+
+  @Override
+  protected void validateRequest() throws RequestHandlerBadRequestException {
+    if (args != null) {
+      images = args.getOrDefault(IMAGE_STRING, "").split(";", 0);
+      sequences = args.getOrDefault(SEQUENCE_STRING, "").split(";", 0);
+      if (args.containsKey(IMAGE_STRING) && !args.get(IMAGE_STRING).startsWith(MAPILLARY_PREFIX)) {
+        throw new RequestHandlerBadRequestException(
+          tr("Only Mapillary images are supported at this time, use photo=Mapillary/{0}", args.get(IMAGE_STRING)));
+      }
+      if (args.containsKey(SEQUENCE_STRING)) {
+        throw new RequestHandlerBadRequestException(
+          tr("Only Mapillary sequences are supported at this time, use sequence=Mapillary/{0}",
+            args.get(SEQUENCE_STRING)));
+      }
+    } else {
+      throw new RequestHandlerBadRequestException(
+        tr("At least one of the optional arguments must be used ({})", String.join(", ", getOptionalParams())));
+    }
+  }
+
+}

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryURL.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryURL.java
@@ -38,6 +38,46 @@ public final class MapillaryURL {
       // Private constructor to avoid instantiation
     }
 
+    /**
+     * Retrieve specific images
+     *
+     * @param key The image key(s)
+     * @return The URL for the image(s)
+     */
+    public static URL getImage(String... key) {
+      if (key.length == 1) {
+        return string2URL(baseUrl, "images/", key[0], queryString(null));
+      } else if (key.length > 1) {
+        return string2URL(baseUrl, "images", queryString(null), "&image_keys=", String.join(",", key));
+      }
+      return null;
+    }
+
+    /**
+     * Retrieve images by sequence
+     *
+     * @param key The sequence keys
+     * @return The URL to get images with
+     */
+    public static URL getImagesBySequences(String... key) {
+      return string2URL(baseUrl, "images", queryString(null), "&sequence_keys=", String.join(",", key));
+    }
+
+    /**
+     * Retrieve specific sequences
+     *
+     * @param key The sequence key(s)
+     * @return The URL for the sequence(s)
+     */
+    public static URL getSequence(String... key) {
+      if (key.length == 1) {
+        return string2URL(baseUrl, "sequences/", key[0], queryString(null));
+      } else if (key.length > 1) {
+        return string2URL(baseUrl, "sequences", queryString(null), "&sequence_keys=", String.join(",", key));
+      }
+      return null;
+    }
+
     public static URL getUser(String key) {
       return string2URL(baseUrl, "users/", key, MapillaryURL.queryString(null));
     }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonDecoder.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonDecoder.java
@@ -47,6 +47,11 @@ public final class JsonDecoder {
           }
         }
       }
+    } else if (json != null && "Feature".equals(json.getString("type", null))) {
+      final T feature = featureDecoder.apply(json);
+      if (feature != null) {
+        result.add(feature);
+      }
     }
     return result;
   }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonImageDetailsDecoder.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/api/JsonImageDetailsDecoder.java
@@ -1,43 +1,102 @@
 // License: GPL. For details, see LICENSE file.
 package org.openstreetmap.josm.plugins.mapillary.utils.api;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
 import javax.json.JsonObject;
 import javax.json.JsonValue;
 
+import org.openstreetmap.josm.plugins.mapillary.MapillaryAbstractImage;
 import org.openstreetmap.josm.plugins.mapillary.MapillaryData;
 import org.openstreetmap.josm.plugins.mapillary.MapillaryImage;
+import org.openstreetmap.josm.plugins.mapillary.MapillarySequence;
+import org.openstreetmap.josm.plugins.mapillary.gui.layer.MapillaryLayer;
 import org.openstreetmap.josm.plugins.mapillary.utils.MapillaryURL.APIv3;
+import org.openstreetmap.josm.tools.Pair;
 
 /**
- * Decodes the JSON returned by {@link APIv3} into Java objects.
- * Takes a {@link JsonObject} and {@link #decodeImageInfos(JsonObject, MapillaryData)} tries to add the timestamps.
+ * Decodes the JSON returned by {@link APIv3} into Java objects. Takes a
+ * {@link JsonObject} and {@link #decodeImageInfos(JsonObject, MapillaryData)}
+ * tries to add the timestamps.
  */
 public final class JsonImageDetailsDecoder {
   private JsonImageDetailsDecoder() {
     // Private constructor to avoid instantiation
   }
 
-  public static void decodeImageInfos(final JsonObject json, final MapillaryData data) {
-    if (data != null) {
-      JsonDecoder.decodeFeatureCollection(json, j -> {
-        decodeImageInfo(j, data);
-        return null;
-      });
-    }
+  /**
+   * Decode a json of image information
+   *
+   * @param json The JSON to decode
+   * @return The added or modified images sorted by sequences
+   */
+  public static Map<String, Collection<MapillaryAbstractImage>> decodeImageInfos(final JsonObject json) {
+    return decodeImageInfos(json, MapillaryLayer.getInstance().getData());
   }
 
-  private static void decodeImageInfo(final JsonObject json, final MapillaryData data) {
+  /**
+   * Decode a json of image information
+   *
+   * @param json The JSON to decode
+   * @param data The data to add the information to
+   * @return The added or modified images sorted by sequences
+   */
+  public static Map<String, Collection<MapillaryAbstractImage>> decodeImageInfos(final JsonObject json,
+      final MapillaryData data) {
+    if (data != null) {
+      return JsonDecoder.decodeFeatureCollection(json, j -> decodeImageInfo(j, data)).stream()
+          .filter(entry -> entry.b != null)
+          .collect(Collectors.groupingBy(p -> p.a, Collector.of(ArrayList<MapillaryAbstractImage>::new,
+              (list, entry) -> list.add(entry.b), (list1, list2) -> {
+                list1.addAll(list2);
+                return list1;
+              })));
+    }
+    return null;
+  }
+
+  /**
+   * Decode a single image info (only use this if the initial type is Feature, not
+   * FeatureCollection)
+   *
+   * @param json The Feature json
+   * @param data The data to add the image info to
+   * @return The MapillaryAbstractImage that was added/modified
+   */
+  private static Pair<String, MapillaryAbstractImage> decodeImageInfo(final JsonObject json,
+      final MapillaryData data) {
     if (json != null && data != null) {
-      JsonValue properties = json.get("properties");
-      if (properties instanceof JsonObject) {
-        String key = ((JsonObject) properties).getString("key", null);
-        Long capturedAt = JsonDecoder.decodeTimestamp(((JsonObject)properties).getString("captured_at", null));
+      JsonValue propertiesValue = json.get("properties");
+      if (propertiesValue instanceof JsonObject) {
+        JsonObject properties = (JsonObject) propertiesValue;
+        String key = properties.getString("key", null);
+        Long capturedAt = JsonDecoder.decodeTimestamp(properties.getString("captured_at", null));
         if (key != null && capturedAt != null) {
-          data.getImages().stream().filter(
-            img -> img instanceof MapillaryImage && key.equals(((MapillaryImage) img).getKey())
-          ).forEach(img -> img.setCapturedAt(capturedAt));
+          MapillaryAbstractImage image = data.getImage(key);
+          if (image == null) {
+            image = new MapillaryImage(key, null, properties.getJsonNumber("ca").doubleValue(),
+                properties.getBoolean("pano", false), properties.getBoolean("private", false));
+            data.add(image);
+          }
+          if (image.getExifCoor() == null) {
+            image.setExifCoor(JsonDecoder.decodeLatLon(json.getJsonObject("geometry").getJsonArray("coordinates")));
+          }
+          image.setCapturedAt(capturedAt);
+          String sequence = properties.getString("sequence_key", "");
+          Optional<MapillarySequence> rSequence = data.getSequences().stream()
+              .filter(seq -> sequence.equals(seq.getKey())).findAny();
+          if (rSequence.isPresent()) {
+            image.setSequence(rSequence.get());
+          }
+          return Pair.create(sequence, image);
         }
       }
     }
+    return null;
   }
 }

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/history/commands/CommandDeleteTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/history/commands/CommandDeleteTest.java
@@ -22,6 +22,7 @@ import org.openstreetmap.josm.testutils.JOSMTestRules;
 
 /**
  * Tests for {@link CommandDelete} class.
+ *
  * @author Kishan
  */
 public class CommandDeleteTest {
@@ -45,7 +46,6 @@ public class CommandDeleteTest {
    */
   @Before
   public void setUp() {
-
     img1 = new MapillaryImage("key1__________________", new LatLon(0.1, 0.1), 90, false, false);
     img2 = new MapillaryImage("key2__________________", new LatLon(0.2, 0.2), 90, false, false);
     img3 = new MapillaryImage("key3__________________", new LatLon(0.3, 0.3), 90, false, false);
@@ -58,8 +58,10 @@ public class CommandDeleteTest {
     seq.add(Arrays.asList(img1, img2, img3));
     orignalSeq = seq;
     data = MapillaryLayer.getInstance().getData();
+    // Ensure that this test is not contaminated by other tests.
+    data.remove(data.getImages());
     data.addAll(Arrays.asList(img1, img2, img3, img4, img5));
-    delete = new CommandDelete(new ConcurrentSkipListSet<>(Arrays.asList(img1,img3,img4,img5)));
+    delete = new CommandDelete(new ConcurrentSkipListSet<>(Arrays.asList(img1, img3, img4, img5)));
     delete.execute();
   }
 
@@ -84,7 +86,7 @@ public class CommandDeleteTest {
     assertEquals(1, data.getImages().size());
     delete.undo();
     assertEquals(5, data.getImages().size());
-    for(MapillaryAbstractImage img : seq.getImages()) {
+    for (MapillaryAbstractImage img : seq.getImages()) {
       assertEquals(orignalSeq.getImages().indexOf(img), seq.getImages().indexOf(img));
     }
   }

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/io/download/SequenceDownloadRunnableTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/io/download/SequenceDownloadRunnableTest.java
@@ -87,7 +87,7 @@ public class SequenceDownloadRunnableTest {
   @Test
   public void testRun5() {
     MapillaryProperties.CUT_OFF_SEQUENCES_AT_BOUNDS.put(true);
-    testNumberOfDecodedImages(0, new Bounds(0, 0, 0, 0));
+    testNumberOfDecodedImages(0, new Bounds(0, 0, 0.000001, 0));
   }
 
   private static void testNumberOfDecodedImages(int expectedNumImgs, Bounds bounds) {


### PR DESCRIPTION
This adds a remote control for the Mapillary plugin. This is to bring feature parity w.r.t. remote control with iD (feature not yet released).

Notes
* /photo endpoint instead of /mapillary, since I have intentions to merge (at least) MS Streetside into this plugin, and I'd rather not require people to update the enpoints
* There were some sonarlint fixes as well
* Some added documentation


Sample URL:
http://127.0.0.1:8111/photo?photo=Mapillary/t6g8zH8K-00W9S30iCtPaQ;Mapillary/rrAJQ0laujGNrP9tQYDGpQ