### PR TITLE
FIXUP: Error when trying to upload images

### DIFF
--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/oauth/UploadUtils.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/oauth/UploadUtils.java
@@ -92,7 +92,7 @@ public final class UploadUtils {
     public SequenceUploadRunnable(Set<MapillaryAbstractImage> images, boolean delete) {
       this.images = images;
       this.uuid = UUID.randomUUID();
-      this.ex = new ThreadPoolExecutor(8, 8, 25, TimeUnit.SECONDS, new ArrayBlockingQueue<>(15));
+      this.ex = new ThreadPoolExecutor(1, Runtime.getRuntime().availableProcessors() * 2, 25, TimeUnit.SECONDS, new ArrayBlockingQueue<>(images.size()));
       this.delete = delete;
     }
 


### PR DESCRIPTION
This fixes #102.

The root issue is that the ArrayBlockingQueue was initialized with a
size of 15, and the network was not fast enough to upload images prior
to filling up the queue and then erroring out.

The fix is using the size of the images set to set the maximum size of
the queue.

Signed-off-by: Taylor Smock <tsmock@fb.com>