### PR TITLE
Fix some NPE's and other issues

### DIFF
--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryData.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/MapillaryData.java
@@ -281,12 +281,21 @@ public class MapillaryData implements Data, Serializable {
   }
 
   /**
+   * Returns a Set containing all visible images. Deleted images are not visible.
+   *
+   * @return A Set object containing all visible images.
+   */
+  public Set<MapillaryAbstractImage> getImages() {
+    return images.stream().filter(MapillaryAbstractImage::isVisible).collect(Collectors.toSet());
+  }
+
+  /**
    * Returns a Set containing all images.
    *
    * @return A Set object containing all images.
    */
-  public Set<MapillaryAbstractImage> getImages() {
-    return images.stream().filter(MapillaryAbstractImage::isVisible).collect(Collectors.toSet());
+  public Set<MapillaryAbstractImage> getAllImages() {
+    return Collections.unmodifiableSet(this.images);
   }
 
   /**

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/data/image/MapillaryImage.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/data/image/MapillaryImage.java
@@ -88,7 +88,7 @@ public class MapillaryImage extends MapillaryAbstractImage implements Detections
       DetectionsDownloadRunnable.get(this);
       this.detectionsForced = true;
     }
-    return detections;
+    return Collections.unmodifiableList(detections);
 
   }
 

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/data/mapillary/ObjectDetections.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/data/mapillary/ObjectDetections.java
@@ -1630,7 +1630,8 @@ public enum ObjectDetections {
 
   OBJECT__SUPPORT__POLE(DetectionType.POINT, DetectionType.SEGMENTATION),
   OBJECT__SUPPORT__TRAFFIC_SIGN_FRAME(DetectionType.POINT, DetectionType.SEGMENTATION),
-  OBJECT__SUPPORT__UTILITY_POLE(DetectionType.POINT, DetectionType.SEGMENTATION),
+  OBJECT__SUPPORT__UTILITY_POLE("man_made=utility_pole", TaggingPresetType.NODE,
+    new DetectionType[] { DetectionType.POINT, DetectionType.SEGMENTATION }, DataType.PREVIEW),
   OBJECT__TRAFFIC_CONE(DetectionType.POINT, DetectionType.SEGMENTATION),
   OBJECT__TRAFFIC_LIGHT__CYCLISTS(Constants.HIGHWAY_TRAFFIC_SIGNALS, TaggingPresetType.NODE,
     new DetectionType[] { DetectionType.POINT, DetectionType.SEGMENTATION }, DataType.PRODUCTION),

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/dialog/MapillaryFilterDialog.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/dialog/MapillaryFilterDialog.java
@@ -328,7 +328,7 @@ public final class MapillaryFilterDialog extends ToggleDialog
     if (MapillaryLayer.hasInstance()) {
       Predicate<MapillaryAbstractImage> shouldHide = this.getShouldHidePredicate();
       if (shouldHide != null) {
-        MapillaryLayer.getInstance().getData().getImages().parallelStream()
+        MapillaryLayer.getInstance().getData().getAllImages().parallelStream()
           .forEach(img -> img.setVisible(!shouldHide.test(img)));
         MapillaryLayer.invalidateInstance();
       }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/dialog/TrafficSignFilter.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/dialog/TrafficSignFilter.java
@@ -488,7 +488,7 @@ public class TrafficSignFilter extends JPanel implements Destroyable, LayerChang
           }
         }
         return null;
-      }).filter(Objects::nonNull).findFirst().orElse(null);
+      }).filter(Objects::nonNull).findFirst().orElse(ImageProvider.createBlankIcon(ImageProvider.ImageSizes.MAP));
       if (icon != null) {
         GuiHelper.runInEDT(() -> {
           ImageCheckBoxButton button = new ImageCheckBoxButton(icon, entry.getKey(),

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/dialog/TrafficSignFilter.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/dialog/TrafficSignFilter.java
@@ -213,7 +213,7 @@ public class TrafficSignFilter extends JPanel implements Destroyable, LayerChang
     if (detectionPage < 0) {
       detectionPage = 0;
     }
-    long visible = buttons.parallelStream().filter(b -> b.isFiltered(filterField.getText())).count();
+    long visible = buttons.parallelStream().filter(b -> checkRelevant(b, filterField.getText())).count();
     while (detectionPage * showMaxNumberModel.getNumber().intValue() > visible) {
       detectionPage--;
     }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/layer/PointObjectLayer.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/layer/PointObjectLayer.java
@@ -888,9 +888,11 @@ public class PointObjectLayer extends AbstractOsmDataLayer implements DataSource
     Collection<OsmPrimitive> currentSelection = data.getSelected();
     if (newImage instanceof MapillaryImage) {
       MapillaryImage image = (MapillaryImage) newImage;
-      Collection<IPrimitive> nodes = image.getDetections(true).parallelStream().map(ImageDetection::getKey)
-        .flatMap(
-          d -> data.getNodes().parallelStream().filter(n -> n.hasKey(DETECTIONS) && n.get(DETECTIONS).contains(d)))
+      this.data.getNodes();
+      Collection<IPrimitive> nodes = image.getDetections(true).parallelStream().map(ImageDetection::getKey).flatMap(
+        // Create a new ArrayList to avoid a ConcurrentModificationException
+        d -> new ArrayList<>(data.getNodes()).parallelStream()
+          .filter(n -> n.hasKey(DETECTIONS) && n.get(DETECTIONS).contains(d)))
         .collect(Collectors.toList());
       if (!nodes.containsAll(currentSelection) && !image.getDetections().isEmpty()
         && !Boolean.TRUE.equals(MapillaryProperties.SMART_EDIT.get())) {

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/layer/PointObjectLayer.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/layer/PointObjectLayer.java
@@ -595,7 +595,9 @@ public class PointObjectLayer extends AbstractOsmDataLayer implements DataSource
         };
         String detections = mapillaryObject.get("detections");
         UndoRedoHandler.getInstance().add(deleteOriginal);
-        UndoRedoHandler.getInstance().add(updateTagsCommand);
+        if (updateTagsCommand != null) {
+          UndoRedoHandler.getInstance().add(updateTagsCommand);
+        }
         try (JsonParser parser = Json
           .createParser(new ByteArrayInputStream(detections.getBytes(StandardCharsets.UTF_8)))) {
           while (parser.hasNext()) {

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/data/mapillary/ObjectDetectionsTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/data/mapillary/ObjectDetectionsTest.java
@@ -2,6 +2,7 @@
 package org.openstreetmap.josm.plugins.mapillary.data.mapillary;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.lang.reflect.Field;
@@ -14,6 +15,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import org.openstreetmap.josm.actions.ExpertToggleAction;
+import org.openstreetmap.josm.plugins.mapillary.gui.DeveloperToggleAction;
 import org.openstreetmap.josm.testutils.JOSMTestRules;
 
 /**
@@ -31,14 +34,22 @@ class ObjectDetectionsTest {
     ObjectDetections.updatePresets();
   }
 
+  /**
+   * Get production object detections for testing
+   *
+   * @return A stream of arguments for object detections that can be added <i>and</i> should be addable by default.
+   */
   static Stream<Arguments> provideObjectDetections() {
+    // Ensure that we are only testing production object detections
+    assertFalse(ExpertToggleAction.isExpert());
+    assertFalse(DeveloperToggleAction.isDeveloper());
     return Stream.of(ObjectDetections.values()).filter(d -> {
       try {
         return osmKey.get(d) != null;
       } catch (ReflectiveOperationException e) {
         return false;
       }
-    }).map(Arguments::of);
+    }).filter(ObjectDetections::shouldBeAddable).map(Arguments::of);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
MapillaryData:
* Avoid sending collection with null object

PointObjectLayer:
* Avoid NPE when user makes no additional modifications to an object
  they are adding
* Avoid LambdaConversionException by not using a method reference. This
  is usually a Sonar Lint issue, but it is currently required.

Signed-off-by: Taylor Smock <tsmock@fb.com>