### PR TITLE
MapillaryUtils: Fix JOSM-20297.

### DIFF
--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryUtils.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryUtils.java
@@ -4,7 +4,6 @@ package org.openstreetmap.josm.plugins.mapillary.utils;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.security.AccessControlException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -379,11 +378,9 @@ public final class MapillaryUtils {
    * @return The default ForkJoin pool
    */
   public static ForkJoinPool getForkJoinPool() {
-    try {
-      return ForkJoinPool.commonPool();
-    } catch (AccessControlException e) {
-      // This will occur when run with Java WebStart.
+    if (Utils.isRunningJavaWebStart()) {
+      return getForkJoinPool(MapillaryUtils.class);
     }
-    return getForkJoinPool(MapillaryUtils.class);
+    return ForkJoinPool.commonPool();
   }
 }


### PR DESCRIPTION
Getting the ForkJoinPool.commonPool doesn't automatically generate an
exception on Java WebStart.

Signed-off-by: Taylor Smock <taylor.smock@kaart.com>