### PR TITLE
Fix JOSM-14729. This occurred when an image didn't have a latlon.

### DIFF
--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryUtils.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryUtils.java
@@ -197,7 +197,9 @@ public final class MapillaryUtils {
       } else {
         zoomBounds = new Bounds(images.iterator().next().getMovingLatLon());
         for (MapillaryAbstractImage img : images) {
-          zoomBounds.extend(img.getMovingLatLon());
+          if (img != null && img.getMovingLatLon() != null) {
+            zoomBounds.extend(img.getMovingLatLon());
+          }
         }
       }
 


### PR DESCRIPTION
Signed-off-by: Taylor Smock <tsmock@fb.com>