### PR TITLE
Alleviate JOSM-20331 (massive slowdown + CPU usage)

### DIFF
--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryUtils.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryUtils.java
@@ -371,7 +371,7 @@ public final class MapillaryUtils {
   public static synchronized ForkJoinPool getForkJoinPool(Class<?> clazz) {
     ForkJoinPool pool = forkJoinPool.get(clazz.getSimpleName());
     if (pool == null || pool.isShutdown()) {
-      pool = Utils.newForkJoinPool("mapillary.forkjoinpool", "mapillary-" + clazz.getSimpleName() + "-%d", 4);
+      pool = Utils.newForkJoinPool("mapillary.forkjoinpool", "mapillary-" + clazz.getSimpleName() + "-%d", 2);
       forkJoinPool.put(clazz.getSimpleName(), pool);
     }
     return pool;


### PR DESCRIPTION
This is due to fetching detections asynchronously, which can take quite
some time and at the default thread priority level, can cause other
issues with other processes and threads.

Signed-off-by: Taylor Smock <tsmock@fb.com>