### PR TITLE
Just add a null check for JOSM 20622. This will probably have consequences.

### DIFF
--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/download/SequenceDownloadRunnable.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/io/download/SequenceDownloadRunnable.java
@@ -82,7 +82,7 @@ public final class SequenceDownloadRunnable extends BoundsDownloadRunnable {
           for (MapillaryAbstractImage img : seq.getImages()) {
             LatLon ll = img.getLatLon();
             data.add(img);
-            if (!boundsCollection.isEmpty() && boundsCollection.stream().noneMatch(b -> b.contains(ll))) {
+            if (ll == null || !boundsCollection.isEmpty() && boundsCollection.stream().noneMatch(b -> b.contains(ll))) {
               img.setDeleted(true);
             }
           }


### PR DESCRIPTION
This pretty much is just a workaround for https://josm.openstreetmap.de/ticket/20622. This will probably break other things, but no one saw fit to give me a bbox where it was occuring.