### PR TITLE
Fix #22471: NPE in MapillaryExportDownloadThread.loadingFinished

### DIFF
--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/cache/CacheUtils.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/cache/CacheUtils.java
@@ -64,10 +64,23 @@ public final class CacheUtils {
      *        The listener that is going to receive the picture.
      */
     public static void submit(INode image, MapillaryCache.Type type, ICachedLoaderListener lis) {
+        submit(image, type, true, lis);
+    }
+
+    /**
+     * Requests the picture with the given key and quality and uses the given
+     * listener.
+     *
+     * @param image
+     *        The picture to be requested.
+     * @param lis
+     *        The listener that is going to receive the picture.
+     */
+    public static void submit(INode image, MapillaryCache.Type type, boolean removeCurrent, ICachedLoaderListener lis) {
         try {
             final MapillaryCache cache = new MapillaryCache(image, type);
             if (cache.getUrl() != null) {
-                cache.submit(lis != null ? lis : IGNORE_DOWNLOAD, false);
+                cache.submit(lis != null ? lis : IGNORE_DOWNLOAD, false, removeCurrent);
             } else {
                 Logging.error("Mapillary: {0} has no url. Maybe API limits have been reached?",
                     MapillaryImageUtils.getKey(image));

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/cache/MapillaryCache.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/cache/MapillaryCache.java
@@ -243,13 +243,25 @@ public class MapillaryCache extends JCSCachedTileLoaderJob<String, BufferedImage
         return new BufferedImageCacheEntry(content);
     }
 
-    @Override
-    public void submit(ICachedLoaderListener listener, boolean force) throws IOException {
+    /**
+     * Submit a new task
+     *
+     * @param listener The listener to notify
+     * @param force {@code true} if the load should skip all caches
+     * @param removeCurrent {@code true} if any outstanding tasks should be canceled
+     * @throws IOException If something happens during fetch ore read
+     */
+    public void submit(ICachedLoaderListener listener, boolean force, boolean removeCurrent) throws IOException {
         // Clear the queue for larger images
-        if (this.type == Type.ORIGINAL || this.type == Type.THUMB_2048) {
+        if (removeCurrent && (this.type == Type.ORIGINAL || this.type == Type.THUMB_2048)) {
             this.cancelOutstandingTasks();
         }
         super.submit(listener, force);
+    }
+
+    @Override
+    public void submit(ICachedLoaderListener listener, boolean force) throws IOException {
+        this.submit(listener, force, true);
     }
 
     @Override

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/io/export/MapillaryExportManagerTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/io/export/MapillaryExportManagerTest.java
@@ -1,0 +1,133 @@
+// License: GPL. For details, see LICENSE file.
+package org.openstreetmap.josm.plugins.mapillary.io.export;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.LogRecord;
+import java.util.stream.Collectors;
+
+import javax.imageio.ImageIO;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.openstreetmap.josm.data.coor.LatLon;
+import org.openstreetmap.josm.gui.MainApplication;
+import org.openstreetmap.josm.plugins.mapillary.cache.MapillaryCache;
+import org.openstreetmap.josm.plugins.mapillary.data.mapillary.MapillaryNode;
+import org.openstreetmap.josm.plugins.mapillary.spi.preferences.MapillaryConfig;
+import org.openstreetmap.josm.plugins.mapillary.testutils.annotations.LoggingHandler;
+import org.openstreetmap.josm.plugins.mapillary.testutils.annotations.MapillaryURLWireMock;
+import org.openstreetmap.josm.plugins.mapillary.utils.MapillaryImageUtils;
+import org.openstreetmap.josm.testutils.annotations.BasicPreferences;
+import org.openstreetmap.josm.testutils.annotations.HTTP;
+import org.openstreetmap.josm.tools.ImageProvider;
+
+/**
+ * Test class for {@link MapillaryExportManager}
+ */
+@BasicPreferences
+@WireMockTest
+@HTTP
+class MapillaryExportManagerTest {
+    @TempDir
+    Path temporaryDirectory;
+
+    @AfterEach
+    void tearDown() {
+        MapillaryConfig.setUrlsProvider(new MapillaryURLWireMock.NullMapillaryUrl());
+    }
+
+    /**
+     * Non-regression test for #22471
+     */
+    @Test
+    @LoggingHandler
+    void testNonRegression22471(WireMockRuntimeInfo wireMockRuntimeInfo, LoggingHandler.TestHandler handler)
+        throws IOException {
+        MapillaryConfig
+            .setUrlsProvider(new MapillaryURLWireMock.WireMockServerMapillaryUrl(wireMockRuntimeInfo.getHttpBaseUrl()));
+        // This needs to be a bit more than the queue limit. Which is the thread limit.
+        int images = 200 * MapillaryCache.THREAD_LIMIT.get();
+        List<MapillaryNode> nodes = generateMapillaryNodes(wireMockRuntimeInfo, images);
+        MapillaryExportManager<MapillaryNode> manager = new MapillaryExportManager<>(nodes,
+            temporaryDirectory.toString());
+        manager.getProgressMonitor().beginTask("testNonRegression22471");
+        manager.realRun();
+        List<LogRecord> records = new ArrayList<>(handler.getRecords());
+        records.removeIf(record -> record.getMessage() != null && record.getMessage().contains("HTTP/1.1 200"));
+        assertTrue(records.isEmpty(),
+            records.stream().map(LogRecord::getMessage).filter(Objects::nonNull).collect(Collectors.joining(", ")));
+        List<Path> files = new ArrayList<>();
+        Files.walkFileTree(this.temporaryDirectory, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                if (file.toFile().isFile()) {
+                    files.add(file);
+                }
+                return super.visitFile(file, attrs);
+            }
+        });
+        assertEquals(images, files.size(), files.stream().map(Path::toString).collect(Collectors.joining(", ")));
+    }
+
+    @Test
+    @LoggingHandler
+    void testNoBlocking(WireMockRuntimeInfo wireMockRuntimeInfo, LoggingHandler.TestHandler handler) {
+        MapillaryConfig
+            .setUrlsProvider(new MapillaryURLWireMock.WireMockServerMapillaryUrl(wireMockRuntimeInfo.getHttpBaseUrl()));
+        List<MapillaryNode> nodes = generateMapillaryNodes(wireMockRuntimeInfo, 10);
+        nodes.forEach(node -> node.setKeys(null));
+        MapillaryExportManager<MapillaryNode> manager = new MapillaryExportManager<>(nodes,
+            temporaryDirectory.toString());
+        Future<?> future = MainApplication.worker.submit(manager);
+        assertDoesNotThrow(() -> future.get(10, TimeUnit.SECONDS));
+        assertTrue(handler.getRecords().isEmpty());
+    }
+
+    private static List<MapillaryNode> generateMapillaryNodes(WireMockRuntimeInfo wireMockRuntimeInfo, int count) {
+        List<MapillaryNode> nodes = new ArrayList<>(count);
+        Image image = ImageProvider.getEmpty(ImageProvider.ImageSizes.SMALLICON).getImage();
+        BufferedImage bufferedImage = new BufferedImage(image.getWidth(null), image.getHeight(null),
+            BufferedImage.TYPE_BYTE_GRAY);
+        Graphics2D g2d = bufferedImage.createGraphics();
+        g2d.drawImage(image, 0, 0, null);
+        g2d.dispose();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        assertDoesNotThrow(() -> ImageIO.write(bufferedImage, "jpg", baos));
+        byte[] emptyImage = baos.toByteArray();
+        for (int i = 1; i <= count; i++) {
+            MapillaryNode node = new MapillaryNode();
+            node.setOsmId(i, 1);
+            node.setCoor(new LatLon(i / 100d, i / 100d));
+            node.put(MapillaryImageUtils.ImageProperties.ID.toString(), Integer.toString(i));
+            node.put(MapillaryImageUtils.ImageProperties.THUMB_ORIGINAL_URL.toString(),
+                wireMockRuntimeInfo.getHttpBaseUrl() + "/image/" + i);
+            node.put(MapillaryImageUtils.ImageProperties.SEQUENCE_ID.toString(), "test-sequence");
+            wireMockRuntimeInfo.getWireMock()
+                .register(WireMock.get("/image/" + i).willReturn(WireMock.aResponse().withBody(emptyImage)));
+            nodes.add(node);
+        }
+        return nodes;
+    }
+}

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/testutils/annotations/LoggingHandler.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/testutils/annotations/LoggingHandler.java
@@ -1,0 +1,104 @@
+// License: GPL. For details, see LICENSE file.
+package org.openstreetmap.josm.plugins.mapillary.testutils.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.openstreetmap.josm.tools.Logging;
+
+/**
+ *
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD })
+@ExtendWith(LoggingHandler.LoggingHandlerImplementation.class)
+public @interface LoggingHandler {
+    class LoggingHandlerImplementation implements BeforeEachCallback, AfterEachCallback, ParameterResolver {
+
+        @Override
+        public void afterEach(ExtensionContext context) {
+            ExtensionContext.Store store = context.getStore(ExtensionContext.Namespace.create(LoggingHandler.class));
+            Logging.getLogger().removeHandler(store.get(TestHandler.class, TestHandler.class));
+            Handler[] handlers = store.get(Logging.class, Handler[].class);
+            for (Handler handler : handlers) {
+                Logging.getLogger().addHandler(handler);
+            }
+        }
+
+        @Override
+        public void beforeEach(ExtensionContext context) {
+            ExtensionContext.Store store = context.getStore(ExtensionContext.Namespace.create(LoggingHandler.class));
+            store.put(Logging.class, Logging.getLogger().getHandlers());
+            for (Handler handler : Logging.getLogger().getHandlers()) {
+                Logging.getLogger().removeHandler(handler);
+            }
+            TestHandler testHandler = new TestHandler();
+            store.put(TestHandler.class, testHandler);
+            Logging.getLogger().addHandler(testHandler);
+        }
+
+        @Override
+        public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+            return TestHandler.class.isAssignableFrom(parameterContext.getParameter().getType());
+        }
+
+        @Override
+        public TestHandler resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+            return extensionContext.getStore(ExtensionContext.Namespace.create(LoggingHandler.class))
+                .get(TestHandler.class, TestHandler.class);
+        }
+    }
+
+    class TestHandler extends Handler {
+        private final List<LogRecord> records = new ArrayList<>();
+
+        /**
+         * Get the records saved by this handler
+         *
+         * @return The saved records
+         */
+        public List<LogRecord> getRecords() {
+            return Collections.unmodifiableList(this.records);
+        }
+
+        /**
+         * Clear stored records
+         */
+        public void clearRecords() {
+            this.records.clear();
+        }
+
+        @Override
+        public void publish(LogRecord record) {
+            this.records.add(record);
+        }
+
+        @Override
+        public void flush() {
+            // Do nothing
+        }
+
+        @Override
+        public void close() throws SecurityException {
+            // Do nothing
+        }
+    }
+}

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/testutils/annotations/MapillaryURLWireMock.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/testutils/annotations/MapillaryURLWireMock.java
@@ -370,25 +370,29 @@ public @interface MapillaryURLWireMock {
      * A wiremocked implementation of {@link IMapillaryUrls}
      */
     class WireMockServerMapillaryUrl implements IMapillaryUrls {
-        final WireMockServer server;
+        final String baseUrl;
 
         WireMockServerMapillaryUrl(WireMockServer server) {
-            this.server = server;
+            this.baseUrl = server.baseUrl();
+        }
+
+        public WireMockServerMapillaryUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
         }
 
         @Override
         public String getBaseMetaDataUrl() {
-            return server.baseUrl() + "/api/v4/graph/";
+            return this.baseUrl + "/api/v4/graph/";
         }
 
         @Override
         public String getBaseTileUrl() {
-            return server.baseUrl() + "/api/v4/coverageTiles/";
+            return this.baseUrl + "/api/v4/coverageTiles/";
         }
 
         @Override
         public String getPaintStyleUrl() {
-            return server.baseUrl() + "/paintstyle";
+            return this.baseUrl + "/paintstyle";
         }
 
         @Override
@@ -408,7 +412,7 @@ public @interface MapillaryURLWireMock {
 
         @Override
         public String getBaseUrl() {
-            return server.baseUrl() + "/baseUrl";
+            return this.baseUrl + "/baseUrl";
         }
     }
 


### PR DESCRIPTION
This was due to killing old download threads as quickly as possible, to avoid filling up the queue and making a user wait.

Signed-off-by: Taylor Smock <tsmock@meta.com>