### PR TITLE
Attempt to fix JOSM Jenkins test failures

### DIFF
--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/workers/MapillaryNodeDownloader.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/workers/MapillaryNodeDownloader.java
@@ -1,7 +1,9 @@
 // License: GPL. For details, see LICENSE file.
 package org.openstreetmap.josm.plugins.mapillary.gui.workers;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
@@ -16,6 +18,7 @@ import org.openstreetmap.josm.tools.JosmRuntimeException;
  * Download a singular node. This is faster than downloading large sequences.
  */
 public class MapillaryNodeDownloader extends MapillaryUIDownloader<MapillaryNode, Void> {
+    private static final List<MapillaryNodeDownloader> downloadList = new ArrayList<>();
     private final long node;
     private final Consumer<MapillaryNode> onFinish;
 
@@ -37,6 +40,7 @@ public class MapillaryNodeDownloader extends MapillaryUIDownloader<MapillaryNode
      */
     public MapillaryNodeDownloader(long id, Consumer<MapillaryNode> onFinish) {
         Objects.requireNonNull(onFinish);
+        downloadList.add(this);
         this.node = id;
         this.onFinish = onFinish;
     }
@@ -57,6 +61,15 @@ public class MapillaryNodeDownloader extends MapillaryUIDownloader<MapillaryNode
             throw new JosmRuntimeException(e);
         } catch (ExecutionException e) {
             throw new JosmRuntimeException(e);
+        }
+    }
+
+    /**
+     * Kill all download threads
+     */
+    static void killAll() {
+        for (MapillaryNodeDownloader downloader : downloadList) {
+            downloader.cancel(true);
         }
     }
 }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/workers/MapillaryNodesDownloader.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/workers/MapillaryNodesDownloader.java
@@ -1,6 +1,7 @@
 // License: GPL. For details, see LICENSE file.
 package org.openstreetmap.josm.plugins.mapillary.gui.workers;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
@@ -15,12 +16,14 @@ import org.openstreetmap.josm.tools.JosmRuntimeException;
  * Download nodes asynchronously
  */
 public class MapillaryNodesDownloader extends MapillaryUIDownloader<List<MapillaryNode>, Void> {
+    private static final List<MapillaryNodesDownloader> downloadList = new ArrayList<>();
     private final Consumer<List<MapillaryNode>> onFinish;
     private final long[] images;
 
     public MapillaryNodesDownloader(Consumer<List<MapillaryNode>> onFinish, long... images) {
         Objects.requireNonNull(onFinish);
         Objects.requireNonNull(images);
+        downloadList.add(this);
         this.onFinish = onFinish;
         this.images = images.clone();
     }
@@ -33,14 +36,29 @@ public class MapillaryNodesDownloader extends MapillaryUIDownloader<List<Mapilla
 
     @Override
     protected void done() {
-        super.done();
         try {
+            super.done();
             this.onFinish.accept(this.get());
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new JosmRuntimeException(e);
         } catch (ExecutionException e) {
             throw new JosmRuntimeException(e);
+        } finally {
+            downloadList.remove(this);
+        }
+    }
+
+    /**
+     * Kill all download threads
+     */
+    public static void killAll() {
+        // Kill the sequence downloader first -- it may cause nodes to be downloaded
+        MapillarySequenceDownloader.killAll();
+        // Kill individual node downloads
+        MapillaryNodeDownloader.killAll();
+        for (MapillaryNodesDownloader downloader : downloadList) {
+            downloader.cancel(true);
         }
     }
 }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/workers/MapillarySequenceDownloader.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/workers/MapillarySequenceDownloader.java
@@ -51,6 +51,16 @@ public class MapillarySequenceDownloader extends MapillaryUIDownloader<Mapillary
     }
 
     /**
+     * Kill all sequence downloads
+     */
+    static synchronized void killAll() {
+        if (currentSequence != null) {
+            currentSequence.cancel(true);
+            currentSequence = null;
+        }
+    }
+
+    /**
      * Create a new sequence downloader
      *
      * @param image The image whose sequence should be downloaded

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/io/remotecontrol/MapillaryRemoteControlTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/io/remotecontrol/MapillaryRemoteControlTest.java
@@ -24,6 +24,7 @@ import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.io.remotecontrol.RemoteControl;
 import org.openstreetmap.josm.io.remotecontrol.handler.RequestHandler;
 import org.openstreetmap.josm.plugins.mapillary.gui.layer.MapillaryLayer;
+import org.openstreetmap.josm.plugins.mapillary.gui.workers.MapillaryNodesDownloader;
 import org.openstreetmap.josm.plugins.mapillary.testutils.annotations.AwaitThreadFinish;
 import org.openstreetmap.josm.plugins.mapillary.testutils.annotations.MapillaryCaches;
 import org.openstreetmap.josm.plugins.mapillary.testutils.annotations.MapillaryLayerAnnotation;
@@ -119,6 +120,8 @@ class MapillaryRemoteControlTest {
         mapillaryRemoteControl.validateRequest();
         mapillaryRemoteControl.handleRequest();
 
+        Awaitility.await().atMost(Durations.TEN_SECONDS)
+            .until(() -> !MainApplication.getLayerManager().getLayersOfType(MapillaryLayer.class).isEmpty());
         Awaitility.await().atMost(Durations.TEN_SECONDS).until(() -> MapillaryLayer.getInstance().getImage() != null);
 
         final String id = request.replaceAll(".*=Mapillary/", "");
@@ -128,6 +131,7 @@ class MapillaryRemoteControlTest {
             assertEquals(id, MapillaryImageUtils.getSequenceKey(MapillaryLayer.getInstance().getImage()));
         }
         assertEquals(1, MainApplication.getLayerManager().getLayersOfType(MapillaryLayer.class).size());
+        MapillaryNodesDownloader.killAll();
     }
 
     @Test


### PR DESCRIPTION
The problem has been irreproducible outside of Jenkins, so this is a "best guess" fix.

What is likely happening is a downloader has not finished downloading before the test completes, but does finish after the layer cleanup occurs.

Signed-off-by: Taylor Smock <tsmock@meta.com>