### PR TITLE
Fix an issue where sequence downloads would reopen the image viewer w…

### DIFF
--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/layer/geoimage/MapillaryImageEntry.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/layer/geoimage/MapillaryImageEntry.java
@@ -86,7 +86,7 @@ public class MapillaryImageEntry
     private static final CacheAccess<Long, MapillaryImageEntry> CACHE = JCSCacheManager
         .getCache("mapillary:mapillaryimageentry");
     private static final String MESSAGE_SEPARATOR = " — ";
-    private final INode image;
+    private INode image;
     private final List<ImageDetection<?>> imageDetections = new ArrayList<>();
     private SoftReference<BufferedImageCacheEntry> originalImage;
     private SoftReference<BufferedImage> layeredImage;
@@ -124,8 +124,7 @@ public class MapillaryImageEntry
             MapillaryImageEntry entry = CACHE.get(id, () -> new MapillaryImageEntry(image));
             if (entry.image.getNumKeys() <= image.getNumKeys()
                 || image != entry.image /* Object reference equality */) {
-                CACHE.remove(id);
-                entry = CACHE.get(id, () -> new MapillaryImageEntry(image));
+                entry.image = image;
             }
             return entry;
         }

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/workers/MapillarySequenceDownloader.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/gui/workers/MapillarySequenceDownloader.java
@@ -11,7 +11,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import org.openstreetmap.josm.data.vector.VectorDataSet;
 import org.openstreetmap.josm.data.vector.VectorNode;
@@ -157,7 +156,7 @@ public class MapillarySequenceDownloader extends MapillaryUIDownloader<Mapillary
             tNode.setOsmId(n.getOsmId(), n.getVersion());
             tNode.setKeys(n.getKeys());
             return tNode;
-        }).collect(Collectors.toList()));
+        }).toList());
         return seq;
     }
 


### PR DESCRIPTION
…indow

This occurs since we want to update the node for the image in the viewer. The image entry was previously immutable, but to avoid the image viewer window reopening problem (and a flicker problem between high res and low res images), it is no longer immutable.