### PR TITLE
Quality of life improvements (pano preview; open external URL)

### DIFF
--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/cache/MapillaryCache.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/cache/MapillaryCache.java
@@ -176,7 +176,7 @@ public class MapillaryCache extends JCSCachedTileLoaderJob<String, BufferedImage
         }
         final IWay<?> iWay = MapillaryImageUtils.getSequence(currentImage);
         // We prefetch both ways
-        final Type type = Type.THUMB_256;
+        final Type type = MapillaryImageUtils.IS_PANORAMIC.test(currentImage) ? Type.THUMB_1024 : Type.THUMB_256; // Prefetch larger pic in case of Pano photo.
         if (iWay != null) {
             // Avoid CME -- getImage may remove nodes from the way
             final List<? extends INode> wayNodes = new ArrayList<>(iWay.getNodes());

--- a/src/main/java/org/openstreetmap/josm/plugins/mapillary/spi/preferences/IMapillaryUrls.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/mapillary/spi/preferences/IMapillaryUrls.java
@@ -320,7 +320,7 @@ public interface IMapillaryUrls {
         if (key == null) {
             throw new IllegalArgumentException("The image key must not be null!");
         }
-        return string2URL(getBaseUrl(), "app/?pKey=", key);
+        return string2URL(getBaseUrl(), "app/?pKey=", key, "&focus=photo");
     }
 
     /**

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryURLTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryURLTest.java
@@ -26,7 +26,7 @@ class MapillaryURLTest {
 
     @Test
     void testBrowseImageURL() {
-        assertEquals(URI.create("https://www.mapillary.com/app/?pKey=1234567890123456789012"),
+        assertEquals(URI.create("https://www.mapillary.com/app/?pKey=1234567890123456789012&focus=photo"),
             MapillaryConfig.getUrls().browseImage("1234567890123456789012"));
     }
 


### PR DESCRIPTION
In case of 360 degree photos 256px preview images are not enough. Here's how they look:
![image](https://github.com/user-attachments/assets/03ba7fec-995f-4374-a021-1760aae9cf7a)
Which is basically pointless.
1024px pic looks like this in such case:
![image](https://github.com/user-attachments/assets/affd5fa5-83f5-4d9e-a58e-2be90d12102d)